### PR TITLE
Pedantic compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@ project(${name})
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                      -Wall -Werror -Weverything -pedantic \
-                     -Wno-unused-variable \
-                     -Wno-c++98-compat -Wno-c++98-compat-pedantic")
+                     -Wno-unused-variable -Wno-padded \
+                     -Wno-c++98-compat -Wno-c++98-compat-pedantic \
+                     -Wno-global-constructors -Wno-exit-time-destructors")
 
 # LLVM
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,11 @@ project(${name})
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                      -Wall -Werror -Weverything -pedantic \
-                     -Wno-unused-variable -Wno-padded \
+                     -Wno-unused-variable -Wno-unused-parameter \
                      -Wno-c++98-compat -Wno-c++98-compat-pedantic \
-                     -Wno-global-constructors -Wno-exit-time-destructors")
+                     -Wno-global-constructors -Wno-exit-time-destructors \
+                     -Wno-c99-extensions \
+                     -Wno-padded")
 
 # LLVM
 
@@ -74,7 +76,7 @@ add_library(
         src/Lexer.cc
         src/Parser2.cc
         src/RT.cc
-        src/Token.cc)
+        src/Token.cc src/Support/Typed.cc)
 
 set_target_properties(
         lib${name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                      -Wno-c++98-compat -Wno-c++98-compat-pedantic \
                      -Wno-global-constructors -Wno-exit-time-destructors \
                      -Wno-c99-extensions \
-                     -Wno-padded")
+                     -Wno-padded -Wno-switch-enum")
 
 # LLVM
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
                      -Wno-c++98-compat -Wno-c++98-compat-pedantic \
                      -Wno-global-constructors -Wno-exit-time-destructors \
                      -Wno-c99-extensions \
-                     -Wno-padded -Wno-switch-enum")
+                     -Wno-padded -Wno-switch-enum \
+                     -Wno-disabled-macro-expansion")
 
 # LLVM
 
@@ -120,7 +121,7 @@ add_executable(
         test/Types/PyStr/type_PyStr.cc
         test/Builtins/truthy/instr_truthy.cc
         test/Builtins/bool/builtin_bool.cc
-        test/Builtins/func/instr_func.cc)
+        test/Builtins/func/instr_func.cc test/include/catch2.h test/include/fakeit.h)
 
 # The test suites depend on an up-to-date llvmPy binary.
 add_dependencies(
@@ -132,8 +133,9 @@ configure_file(
 
 target_include_directories(
         ${name}Test
+        PRIVATE test/include
         PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/library/FakeIt/single_header/catch)
+        PRIVATE library/FakeIt/single_header/catch)
 
 target_link_libraries(
         ${name}Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ set(name llvmPy)
 project(${name})
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-variable")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+                     -Wall -Werror -Weverything -pedantic \
+                     -Wno-unused-variable \
+                     -Wno-c++98-compat -Wno-c++98-compat-pedantic")
 
 # LLVM
 

--- a/include/llvmPy/AST.h
+++ b/include/llvmPy/AST.h
@@ -12,7 +12,7 @@ using ArgNamesIter = iterator_range<std::string const *>;
 
 class AST : public Typed {
 public:
-    virtual ~AST() = default;
+    virtual ~AST();
 
     virtual void toStream(std::ostream &s) const;
 
@@ -20,6 +20,9 @@ public:
 };
 
 class Expr : public AST {
+public:
+    virtual ~Expr();
+
 protected:
     Expr();
 };
@@ -33,7 +36,7 @@ public:
     std::string const &getValue() const;
 
 private:
-    std::string const value;
+    std::string const value_;
 };
 
 class DecimalExpr final : public Expr {
@@ -69,7 +72,7 @@ public:
     std::string const &getName() const;
 
 private:
-    std::string const name;
+    std::string const name_;
 };
 
 class LambdaExpr final : public Expr {
@@ -93,7 +96,7 @@ public:
 private:
     std::vector<std::string> args_;
 
-    std::shared_ptr<Expr const> expr;
+    std::shared_ptr<Expr const> expr_;
 };
 
 class UnaryExpr final : public Expr {
@@ -107,8 +110,8 @@ public:
     Expr const &getExpr() const;
 
 private:
-    TokenType const op;
-    std::shared_ptr<Expr const> expr;
+    TokenType const op_;
+    std::shared_ptr<Expr const> expr_;
 };
 
 class BinaryExpr final : public Expr {
@@ -127,9 +130,9 @@ public:
     TokenType getOperator() const;
 
 private:
-    std::shared_ptr<Expr const> lhs;
-    std::shared_ptr<Expr const> rhs;
-    TokenType const op;
+    std::shared_ptr<Expr const> lhs_;
+    std::shared_ptr<Expr const> rhs_;
+    TokenType const op_;
 };
 
 class CallExpr final : public Expr {
@@ -146,7 +149,7 @@ public:
     void addArgument(std::shared_ptr<Expr const> argument);
 
 private:
-    std::shared_ptr<Expr const> callee;
+    std::shared_ptr<Expr const> callee_;
 
     std::vector<std::shared_ptr<Expr const>> arguments;
 };
@@ -180,6 +183,9 @@ private:
 };
 
 class Stmt : public AST {
+public:
+    virtual ~Stmt();
+
 protected:
     Stmt();
 };

--- a/include/llvmPy/AST.h
+++ b/include/llvmPy/AST.h
@@ -36,31 +36,31 @@ public:
     std::string const &getValue() const;
 
 private:
-    std::string const value_;
+    std::string const _value;
 };
 
 class DecimalExpr final : public Expr {
 public:
-    explicit DecimalExpr(double v);
+    explicit DecimalExpr(double value);
 
     void toStream(std::ostream &s) const override;
 
     double getValue() const;
 
 private:
-    double const value;
+    double const _value;
 };
 
 class IntegerExpr final : public Expr {
 public:
-    explicit IntegerExpr(long v);
+    explicit IntegerExpr(long value);
 
     void toStream(std::ostream &s) const override;
 
     int64_t getValue() const;
 
 private:
-    long const value;
+    long const _value;
 };
 
 class IdentExpr final : public Expr {
@@ -72,7 +72,7 @@ public:
     std::string const &getName() const;
 
 private:
-    std::string const name_;
+    std::string const _name;
 };
 
 class LambdaExpr final : public Expr {
@@ -94,9 +94,9 @@ public:
     void addArgument(std::string const &argument);
 
 private:
-    std::vector<std::string> args_;
+    std::vector<std::string> _args;
 
-    std::shared_ptr<Expr const> expr_;
+    std::shared_ptr<Expr const> _expr;
 };
 
 class UnaryExpr final : public Expr {
@@ -110,8 +110,8 @@ public:
     Expr const &getExpr() const;
 
 private:
-    TokenType const op_;
-    std::shared_ptr<Expr const> expr_;
+    TokenType const _operator;
+    std::shared_ptr<Expr const> _expr;
 };
 
 class BinaryExpr final : public Expr {
@@ -130,9 +130,9 @@ public:
     TokenType getOperator() const;
 
 private:
-    std::shared_ptr<Expr const> lhs_;
-    std::shared_ptr<Expr const> rhs_;
-    TokenType const op_;
+    std::shared_ptr<Expr const> _lhs;
+    std::shared_ptr<Expr const> _rhs;
+    TokenType const _operator;
 };
 
 class CallExpr final : public Expr {
@@ -149,9 +149,9 @@ public:
     void addArgument(std::shared_ptr<Expr const> argument);
 
 private:
-    std::shared_ptr<Expr const> callee_;
+    std::shared_ptr<Expr const> _callee;
 
-    std::vector<std::shared_ptr<Expr const>> arguments;
+    std::vector<std::shared_ptr<Expr const>> _arguments;
 };
 
 class TokenExpr final : public Expr {
@@ -163,7 +163,7 @@ public:
     TokenType getTokenType() const;
 
 private:
-    TokenType tokenType;
+    TokenType _tokenType;
 };
 
 /** A group consists of expressions separated by comma (a tuple). */
@@ -179,7 +179,7 @@ public:
     void addMember(std::shared_ptr<Expr> member);
 
 private:
-    std::vector<std::shared_ptr<Expr const>> members;
+    std::vector<std::shared_ptr<Expr const>> _members;
 };
 
 class Stmt : public AST {
@@ -199,7 +199,7 @@ public:
     Expr const &getExpr() const;
 
 private:
-    std::shared_ptr<Expr const> expr;
+    std::shared_ptr<Expr const> _expr;
 };
 
 class AssignStmt final : public Stmt {
@@ -217,8 +217,8 @@ public:
     std::shared_ptr<Expr const> const &getValuePtr() const;
 
 private:
-    std::string const name;
-    std::shared_ptr<Expr const> value;
+    std::string const _name;
+    std::shared_ptr<Expr const> _value;
 };
 
 class DefStmt final : public Stmt {
@@ -241,9 +241,9 @@ public:
     Stmt const &getBody() const;
 
 private:
-    std::string const name;
-    std::vector<std::string> args_;
-    std::shared_ptr<Stmt const> body;
+    std::string const _name;
+    std::vector<std::string> _args;
+    std::shared_ptr<Stmt const> _body;
 };
 
 class ReturnStmt final : public Stmt {
@@ -257,7 +257,7 @@ public:
     std::shared_ptr<Expr const> const &getExprPtr() const;
 
 private:
-    std::shared_ptr<Expr const> expr;
+    std::shared_ptr<Expr const> _expr;
 };
 
 class CompoundStmt final : public Stmt {
@@ -271,7 +271,7 @@ public:
     void addStatement(std::shared_ptr<Stmt const> const &stmt);
 
 private:
-    std::vector<std::shared_ptr<Stmt const>> statements;
+    std::vector<std::shared_ptr<Stmt const>> _statements;
 };
 
 class PassStmt final : public Stmt {
@@ -298,9 +298,9 @@ public:
     Stmt const &getElseBranch() const;
 
 private:
-    std::shared_ptr<Expr const> condition;
-    std::shared_ptr<Stmt const> thenBranch;
-    std::shared_ptr<Stmt const> elseBranch;
+    std::shared_ptr<Expr const> _condition;
+    std::shared_ptr<Stmt const> _thenBranch;
+    std::shared_ptr<Stmt const> _elseBranch;
 };
 
 class WhileStmt final : public Stmt {
@@ -317,8 +317,8 @@ public:
     Stmt const &getBody() const;
 
 private:
-    std::shared_ptr<Expr const> condition;
-    std::shared_ptr<Stmt const> body;
+    std::shared_ptr<Expr const> _condition;
+    std::shared_ptr<Stmt const> _body;
 };
 
 class BreakStmt final : public Stmt {

--- a/include/llvmPy/Compiler.h
+++ b/include/llvmPy/Compiler.h
@@ -22,12 +22,12 @@ public:
     void addAndRunModule(std::unique_ptr<llvm::Module> module);
 
 public:
-    llvm::LLVMContext &getContext() { return ctx; }
+    llvm::LLVMContext &getContext() { return _ctx; }
     llvm::DataLayout const &getDataLayout() const;
 
 private:
-    llvm::LLVMContext ctx;
-    std::unique_ptr<CompilerImpl> const impl;
+    llvm::LLVMContext _ctx;
+    std::unique_ptr<CompilerImpl> const _impl;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/Compiler.h
+++ b/include/llvmPy/Compiler.h
@@ -1,6 +1,12 @@
 #pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/LLVMContext.h>
+#pragma GCC diagnostic pop
+
 #include <vector>
 #include <memory>
 

--- a/include/llvmPy/Emitter.h
+++ b/include/llvmPy/Emitter.h
@@ -91,10 +91,10 @@ public:
             iterator_range<std::string const *> const &args);
 
 private:
-    llvm::DataLayout const &dl;
-    llvm::LLVMContext &ctx;
-    llvm::IRBuilder<> ir;
-    Types const types;
+    llvm::DataLayout const &_dl;
+    llvm::LLVMContext &_ctx;
+    llvm::IRBuilder<> _ir;
+    Types const _types;
 
     bool lastInstructionWasTerminator() const;
 };

--- a/include/llvmPy/Emitter.h
+++ b/include/llvmPy/Emitter.h
@@ -1,8 +1,14 @@
 #pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <llvm/IR/IRBuilder.h>
+#pragma GCC diagnostic pop
+
 #include <llvmPy/AST.h>
 #include <llvmPy/Compiler.h>
 #include <llvmPy/Instr.h>
-#include <llvm/IR/IRBuilder.h>
 #include <llvmPy/Support/iterator_range.h>
 #include <set>
 

--- a/include/llvmPy/Instr.h
+++ b/include/llvmPy/Instr.h
@@ -61,16 +61,19 @@ public:
     llvm::ConstantInt *getInt64(int64_t value) const;
     llvm::PointerType *getPtr(llvm::Type *type) const;
 
-    llvm::FunctionType *getOpaqueFunc(int N) const;
+    llvm::FunctionType *getOpaqueFunc(size_t N) const;
 
     llvm::FunctionType *
     getFunc(
             std::string const &name,
             llvm::StructType *outer,
-            int N) const;
+            size_t N) const;
 
     llvm::StructType *
-    getFuncFrame(std::string const &name, llvm::StructType *outer, int N) const;
+    getFuncFrame(
+            std::string const &name,
+            llvm::StructType *outer,
+            size_t N) const;
 
 private:
     llvm::LLVMContext &ctx;

--- a/include/llvmPy/Instr.h
+++ b/include/llvmPy/Instr.h
@@ -76,7 +76,7 @@ public:
             size_t N) const;
 
 private:
-    llvm::LLVMContext &ctx;
+    llvm::LLVMContext &_ctx;
 };
 
 Frame *moveFrameToHeap(Frame *frame, Scope const &scope);

--- a/include/llvmPy/Lexer.h
+++ b/include/llvmPy/Lexer.h
@@ -21,17 +21,17 @@ public:
     bool isEof();
 
 private:
-    std::istream & stream;
-    std::vector<Token> tokens;
-    std::map<std::string const, TokenType> const keywords;
-    char ch;
-    char buf[BUFFER_SIZE];
-    long ibuf;
-    long ilast;
+    std::istream &_stream;
+    std::vector<Token> _tokens;
+    std::map<std::string const, TokenType> const _keywords;
+    char _ch;
+    char _buf[BUFFER_SIZE];
+    long _ibuf;
+    long _ilast;
 
-    long line;
-    long col;
-    std::string error;
+    long _line;
+    long _col;
+    std::string _error;
 
     void add(Token);
 

--- a/include/llvmPy/Lexer.h
+++ b/include/llvmPy/Lexer.h
@@ -26,8 +26,8 @@ private:
     std::map<std::string const, TokenType> const _keywords;
     char _ch;
     char _buf[BUFFER_SIZE];
-    long _ibuf;
-    long _ilast;
+    ssize_t _ibuf;
+    ssize_t _ilast;
 
     long _line;
     long _col;

--- a/include/llvmPy/Parser2.h
+++ b/include/llvmPy/Parser2.h
@@ -56,14 +56,14 @@ protected:
     void back();
 
 private:
-    TTokenIter &iter;
-    TTokenIter iter_end;
+    TTokenIter &_iter;
+    TTokenIter _iterEnd;
     Token &token() const;
 
     int getPrecedence(TokenType tokenType) const;
     int getPrecedence(TokenExpr *tokenExpr) const;
 
-    std::map<TokenType, int> const precedences;
+    std::map<TokenType, int> const _precedences;
 
     void expectIndent(int indent);
 };

--- a/include/llvmPy/PyObj/PyBool.h
+++ b/include/llvmPy/PyObj/PyBool.h
@@ -18,8 +18,17 @@ public:
     bool py__bool__() override;
 
 private:
-    bool const value;
+    bool const value_;
 };
 
 } // namespace llvmPy
+
+extern "C" {
+#endif // __cplusplus
+
+extern llvmPy::PyBool llvmPy_True;
+extern llvmPy::PyBool llvmPy_False;
+
+#ifdef __cplusplus
+}
 #endif // __cplusplus

--- a/include/llvmPy/PyObj/PyBool.h
+++ b/include/llvmPy/PyObj/PyBool.h
@@ -18,7 +18,7 @@ public:
     bool py__bool__() override;
 
 private:
-    bool const value_;
+    bool const _value;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/PyObj/PyFunc.h
+++ b/include/llvmPy/PyObj/PyFunc.h
@@ -18,8 +18,8 @@ public:
     void *getLabel() const;
 
 private:
-    Frame *frame_;
-    void * const label_;
+    Frame *_frame;
+    void * const _label;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/PyObj/PyInt.h
+++ b/include/llvmPy/PyObj/PyInt.h
@@ -27,7 +27,7 @@ public:
 private:
     static constexpr int InvalidCmp = ~0;
 
-    int64_t value;
+    int64_t value_;
     int cmp(PyObj &rhs, bool throwIfInvalid);
 };
 

--- a/include/llvmPy/PyObj/PyInt.h
+++ b/include/llvmPy/PyObj/PyInt.h
@@ -27,7 +27,7 @@ public:
 private:
     static constexpr int InvalidCmp = ~0;
 
-    int64_t value_;
+    int64_t _value;
     int cmp(PyObj &rhs, bool throwIfInvalid);
 };
 

--- a/include/llvmPy/PyObj/PyNone.h
+++ b/include/llvmPy/PyObj/PyNone.h
@@ -18,4 +18,12 @@ public:
 };
 
 } // namespace llvmPy
+
+extern "C" {
+#endif // __cplusplus
+
+extern llvmPy::PyNone llvmPy_None;
+
+#ifdef __cplusplus
+}
 #endif // __cplusplus

--- a/include/llvmPy/PyObj/PyObj.h
+++ b/include/llvmPy/PyObj/PyObj.h
@@ -13,6 +13,8 @@ class PyObj : public Typed {
 public:
     PyObj();
 
+    virtual ~PyObj();
+
     virtual std::string py__str__();
 
     virtual bool py__bool__();

--- a/include/llvmPy/PyObj/PyStr.h
+++ b/include/llvmPy/PyObj/PyStr.h
@@ -28,7 +28,7 @@ public:
     PyObj *py__add__(PyObj &rhs) override;
 
 private:
-    std::unique_ptr<std::string const> value_;
+    std::unique_ptr<std::string const> _value;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/PyObj/PyStr.h
+++ b/include/llvmPy/PyObj/PyStr.h
@@ -28,7 +28,7 @@ public:
     PyObj *py__add__(PyObj &rhs) override;
 
 private:
-    std::unique_ptr<std::string const> value;
+    std::unique_ptr<std::string const> value_;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/RT.h
+++ b/include/llvmPy/RT.h
@@ -15,7 +15,7 @@ public:
     void import(RTModule &mod);
 
 private:
-    Compiler &compiler;
+    Compiler &_compiler;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/RT/RTModule.h
+++ b/include/llvmPy/RT/RTModule.h
@@ -31,8 +31,8 @@ public:
             Types const &types);
 
 public:
-    llvm::Module &getModule() const { return ir; }
-    RTScope &getScope() { return scope; }
+    llvm::Module &getModule() const { return _ir; }
+    RTScope &getScope() { return _scope; }
 
 public:
     llvm::Value *llvmPy_add() const;
@@ -62,9 +62,9 @@ public:
     llvm::GlobalVariable *llvmPy_PyStr(std::string const &value);
 
 private:
-    llvm::Module &ir;
-    Types const &types;
-    RTScope scope;
+    llvm::Module &_ir;
+    Types const &_types;
+    RTScope _scope;
 
     llvm::GlobalVariable *getOrCreateGlobalExtern(std::string const &name) const;
     std::unordered_map<std::string, llvm::GlobalVariable *> strings_;

--- a/include/llvmPy/RT/RTScope.h
+++ b/include/llvmPy/RT/RTScope.h
@@ -71,7 +71,7 @@ public:
     size_t getNextWhileStmtIndex();
 
 private:
-    RTModule &module;
+    RTModule &module_;
     llvm::Value *innerFramePtr;
     llvm::Value *innerFramePtrPtr;
     llvm::StructType *innerFrameType;

--- a/include/llvmPy/RT/RTScope.h
+++ b/include/llvmPy/RT/RTScope.h
@@ -71,16 +71,14 @@ public:
     size_t getNextWhileStmtIndex();
 
 private:
-    RTModule &module_;
-    llvm::Value *innerFramePtr;
-    llvm::Value *innerFramePtrPtr;
-    llvm::StructType *innerFrameType;
-    llvm::StructType *outerFrameType;
-    size_t condStmtCount;
-    size_t whileStmtCount;
-
-    std::unordered_map<std::string, Slot> slots;
-
+    RTModule &_module;
+    llvm::Value *_innerFramePtr;
+    llvm::Value *_innerFramePtrPtr;
+    llvm::StructType *_innerFrameType;
+    llvm::StructType *_outerFrameType;
+    size_t _condStmtCount;
+    size_t _whileStmtCount;
+    std::unordered_map<std::string, Slot> _slots;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/RT/Scope.h
+++ b/include/llvmPy/RT/Scope.h
@@ -21,7 +21,7 @@ public:
     virtual size_t getSlotCount() const = 0;
 
 private:
-    Scope * const parent_;
+    Scope * const _parent;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/RT/Scope.h
+++ b/include/llvmPy/RT/Scope.h
@@ -14,14 +14,14 @@ public:
 
     virtual ~Scope();
 
-    __mock_virtual bool hasParent() const;
+    MOCK_VIRTUAL bool hasParent() const;
 
-    __mock_virtual Scope &getParent() const;
+    MOCK_VIRTUAL Scope &getParent() const;
 
     virtual size_t getSlotCount() const = 0;
 
 private:
-    Scope * const parent;
+    Scope * const parent_;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/Support/Testing.h
+++ b/include/llvmPy/Support/Testing.h
@@ -3,7 +3,7 @@
 // __mock_virtual methods can be stubbed and spied in tests.
 
 #ifndef NDEBUG
-#define __mock_virtual virtual
+#define MOCK_VIRTUAL virtual
 #else
-#define __mock_virtual
+#define MOCK_VIRTUAL
 #endif

--- a/include/llvmPy/Support/iterator_range.h
+++ b/include/llvmPy/Support/iterator_range.h
@@ -1,5 +1,10 @@
 #pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <llvm/ADT/iterator_range.h>
+#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 namespace llvmPy {

--- a/include/llvmPy/Token.h
+++ b/include/llvmPy/Token.h
@@ -86,11 +86,11 @@ public:
     size_t getDepth() const;
 
 private:
-    TokenType const type;
+    TokenType const _type;
 
-    std::unique_ptr<std::string const> str;
+    std::unique_ptr<std::string const> _str;
 
-    size_t const depth;
+    size_t const _depth;
 };
 
 } // namespace llvmPy

--- a/include/llvmPy/Typed.h
+++ b/include/llvmPy/Typed.h
@@ -8,7 +8,7 @@ namespace llvmPy {
 class Typed {
 public:
     // Ensure the class is polymorphic.
-    virtual ~Typed() = default;
+    virtual ~Typed();
 
     template<class K>
     bool isa() {

--- a/library/llvmPyLitParse/include/llvmPy/LitParser.h
+++ b/library/llvmPyLitParse/include/llvmPy/LitParser.h
@@ -42,12 +42,12 @@ public:
     int getMaxProgress() const;
 
 private:
-    LitResultCode resultCode_;
-    std::string suiteName_;
-    std::string testName_;
-    std::string output_;
-    int const currentProgress_;
-    int const maxProgress_;
+    LitResultCode _resultCode;
+    std::string _suiteName;
+    std::string _testName;
+    std::string _output;
+    int const _currentProgress;
+    int const _maxProgress;
 };
 
 /**
@@ -63,10 +63,10 @@ public:
     std::vector<LitTestResult *> getResults() const;
 
 private:
-    std::istream &stream_;
-    std::vector<LitTestResult *> results_;
-    char line_[1024];
-    char ch_;
+    std::istream &_stream;
+    std::vector<LitTestResult *> _results;
+    char _line[1024];
+    char _ch;
 
     char get();
     void next();

--- a/library/llvmPyLitParse/include/llvmPy/LitParser.h
+++ b/library/llvmPyLitParse/include/llvmPy/LitParser.h
@@ -42,12 +42,12 @@ public:
     int getMaxProgress() const;
 
 private:
-    LitResultCode resultCode;
-    std::string suiteName;
-    std::string testName;
-    std::string output;
-    int const currentProgress;
-    int const maxProgress;
+    LitResultCode resultCode_;
+    std::string suiteName_;
+    std::string testName_;
+    std::string output_;
+    int const currentProgress_;
+    int const maxProgress_;
 };
 
 /**
@@ -63,10 +63,10 @@ public:
     std::vector<LitTestResult *> getResults() const;
 
 private:
-    std::istream &stream;
-    std::vector<LitTestResult *> results;
-    char line[1024];
-    char ch;
+    std::istream &stream_;
+    std::vector<LitTestResult *> results_;
+    char line_[1024];
+    char ch_;
 
     char get();
     void next();

--- a/library/llvmPyLitParse/src/LitParser.cc
+++ b/library/llvmPyLitParse/src/LitParser.cc
@@ -14,59 +14,59 @@ LitTestResult::LitTestResult(
         std::string const &output,
         int currentProgress,
         int maxProgress)
-: resultCode(resultCode),
-  suiteName(suiteName),
-  testName(testName),
-  output(output),
-  currentProgress(currentProgress),
-  maxProgress(maxProgress)
+: resultCode_(resultCode),
+  suiteName_(suiteName),
+  testName_(testName),
+  output_(output),
+  currentProgress_(currentProgress),
+  maxProgress_(maxProgress)
 {
 }
 
 LitResultCode
 LitTestResult::getResultCode() const
 {
-    return resultCode;
+    return resultCode_;
 }
 
 std::string
 LitTestResult::getSuiteName() const
 {
-    return suiteName;
+    return suiteName_;
 }
 
 std::string
 LitTestResult::getTestName() const
 {
-    return testName;
+    return testName_;
 }
 
 std::string
 LitTestResult::getOutput() const
 {
-    return output;
+    return output_;
 }
 
 int
 LitTestResult::getCurrentProgress() const
 {
-    return currentProgress;
+    return currentProgress_;
 }
 
 int
 LitTestResult::getMaxProgress() const
 {
-    return maxProgress;
+    return maxProgress_;
 }
 
 LitParser::LitParser(std::istream &stream)
-: stream(stream)
+: stream_(stream)
 {
     next();
 }
 
 LitParser::LitParser(std::string const &input)
-: stream(*new std::istringstream(input)) // XXX
+: stream_(*new std::istringstream(input)) // XXX
 {
     next();
 }
@@ -74,7 +74,7 @@ LitParser::LitParser(std::string const &input)
 std::vector<LitTestResult *>
 LitParser::getResults() const
 {
-    return results;
+    return results_;
 }
 
 LitTestResult *
@@ -138,7 +138,7 @@ LitParser::parse()
     while (true) {
         LitTestResult *result = parseNext();
         if (result) {
-            results.push_back(result);
+            results_.push_back(result);
         }
 
         if (isEof()) {
@@ -150,13 +150,13 @@ LitParser::parse()
 char
 LitParser::get()
 {
-    return ch;
+    return ch_;
 }
 
 void
 LitParser::next()
 {
-    ch = (char) stream.get();
+    ch_ = static_cast<char>(stream_.get());
 }
 
 bool
@@ -174,7 +174,7 @@ LitParser::isEol()
 bool
 LitParser::isEof()
 {
-    return ch == (char) eof;
+    return ch_ == static_cast<char>(eof);
 }
 
 bool
@@ -287,11 +287,11 @@ LitParser::isOutput(std::string *output)
     ss << get();
 
     while (true) {
-        stream.getline(line, sizeof(line));
-        if (isLogDelineator(line)) {
+        stream_.getline(line_, sizeof(line_));
+        if (isLogDelineator(line_)) {
             break;
         } else {
-            ss << line << "\n";
+            ss << line_ << "\n";
         }
     }
 

--- a/library/llvmPyLitParse/src/LitParser.cc
+++ b/library/llvmPyLitParse/src/LitParser.cc
@@ -14,59 +14,59 @@ LitTestResult::LitTestResult(
         std::string const &output,
         int currentProgress,
         int maxProgress)
-: resultCode_(resultCode),
-  suiteName_(suiteName),
-  testName_(testName),
-  output_(output),
-  currentProgress_(currentProgress),
-  maxProgress_(maxProgress)
+: _resultCode(resultCode),
+  _suiteName(suiteName),
+  _testName(testName),
+  _output(output),
+  _currentProgress(currentProgress),
+  _maxProgress(maxProgress)
 {
 }
 
 LitResultCode
 LitTestResult::getResultCode() const
 {
-    return resultCode_;
+    return _resultCode;
 }
 
 std::string
 LitTestResult::getSuiteName() const
 {
-    return suiteName_;
+    return _suiteName;
 }
 
 std::string
 LitTestResult::getTestName() const
 {
-    return testName_;
+    return _testName;
 }
 
 std::string
 LitTestResult::getOutput() const
 {
-    return output_;
+    return _output;
 }
 
 int
 LitTestResult::getCurrentProgress() const
 {
-    return currentProgress_;
+    return _currentProgress;
 }
 
 int
 LitTestResult::getMaxProgress() const
 {
-    return maxProgress_;
+    return _maxProgress;
 }
 
 LitParser::LitParser(std::istream &stream)
-: stream_(stream)
+: _stream(stream)
 {
     next();
 }
 
 LitParser::LitParser(std::string const &input)
-: stream_(*new std::istringstream(input)) // XXX
+: _stream(*new std::istringstream(input)) // XXX
 {
     next();
 }
@@ -74,7 +74,7 @@ LitParser::LitParser(std::string const &input)
 std::vector<LitTestResult *>
 LitParser::getResults() const
 {
-    return results_;
+    return _results;
 }
 
 LitTestResult *
@@ -138,7 +138,7 @@ LitParser::parse()
     while (true) {
         LitTestResult *result = parseNext();
         if (result) {
-            results_.push_back(result);
+            _results.push_back(result);
         }
 
         if (isEof()) {
@@ -150,13 +150,13 @@ LitParser::parse()
 char
 LitParser::get()
 {
-    return ch_;
+    return _ch;
 }
 
 void
 LitParser::next()
 {
-    ch_ = static_cast<char>(stream_.get());
+    _ch = static_cast<char>(_stream.get());
 }
 
 bool
@@ -174,7 +174,7 @@ LitParser::isEol()
 bool
 LitParser::isEof()
 {
-    return ch_ == static_cast<char>(eof);
+    return _ch == static_cast<char>(eof);
 }
 
 bool
@@ -287,11 +287,11 @@ LitParser::isOutput(std::string *output)
     ss << get();
 
     while (true) {
-        stream_.getline(line_, sizeof(line_));
-        if (isLogDelineator(line_)) {
+        _stream.getline(_line, sizeof(_line));
+        if (isLogDelineator(_line)) {
             break;
         } else {
-            ss << line_ << "\n";
+            ss << _line << "\n";
         }
     }
 

--- a/src/AST.cc
+++ b/src/AST.cc
@@ -9,7 +9,7 @@ using std::endl;
 static constexpr int INDENT = 4;
 
 static void
-indentToStream(ostream &s, Stmt const &stmt, int indent)
+indentToStream(ostream &s, Stmt const &stmt, size_t indent)
 {
     std::stringstream ss;
     ss << stmt;
@@ -31,6 +31,12 @@ indentToStream(ostream &s, Stmt const &stmt, int indent)
         s << std::endl; // getline() discards the delimiter.
     }
 }
+
+AST::~AST() = default;
+
+Expr::~Expr() = default;
+
+Stmt::~Stmt() = default;
 
 std::string
 AST::toString() const
@@ -87,14 +93,14 @@ IntegerExpr::toStream(std::ostream &s) const
 }
 
 IdentExpr::IdentExpr(std::string const &name)
-: name(name)
+: name_(name)
 {
 }
 
 std::string const &
 IdentExpr::getName() const
 {
-    return name;
+    return name_;
 }
 
 void
@@ -104,7 +110,7 @@ IdentExpr::toStream(std::ostream &s) const
 }
 
 LambdaExpr::LambdaExpr(std::shared_ptr<Expr> const &expr)
-: expr(expr)
+: expr_(expr)
 {
 }
 
@@ -135,8 +141,8 @@ LambdaExpr::arg_end() const
 Expr const &
 LambdaExpr::getExpr() const
 {
-    assert(expr);
-    return *expr;
+    assert(expr_);
+    return *expr_;
 }
 
 void
@@ -161,7 +167,7 @@ BinaryExpr::BinaryExpr(
         std::shared_ptr<Expr const> const &lhs,
         TokenType op,
         std::shared_ptr<Expr const> const &rhs)
-: lhs(lhs), rhs(rhs), op(op)
+: lhs_(lhs), rhs_(rhs), op_(op)
 {
 }
 
@@ -176,21 +182,21 @@ BinaryExpr::toStream(std::ostream &s) const
 Expr const &
 BinaryExpr::getLeftOperand() const
 {
-    assert(lhs);
-    return *lhs;
+    assert(lhs_);
+    return *lhs_;
 }
 
 Expr const &
 BinaryExpr::getRightOperand() const
 {
-    assert(rhs);
-    return *rhs;
+    assert(rhs_);
+    return *rhs_;
 }
 
 TokenType
 BinaryExpr::getOperator() const
 {
-    return op;
+    return op_;
 }
 
 void
@@ -264,26 +270,26 @@ operator<< (std::ostream & s, Stmt const & stmt)
 }
 
 StringExpr::StringExpr(std::string const &value)
-: value(value)
+: value_(value)
 {
 }
 
 std::string const &
 StringExpr::getValue() const
 {
-    return value;
+    return value_;
 }
 
 CallExpr::CallExpr(std::shared_ptr<Expr> const &callee)
-: callee(callee)
+: callee_(callee)
 {
 }
 
 Expr const &
 CallExpr::getCallee() const
 {
-    assert(callee);
-    return *callee;
+    assert(callee_);
+    return *callee_;
 }
 
 std::vector<std::shared_ptr<Expr const>> const &
@@ -354,7 +360,7 @@ TokenExpr::getTokenType() const
 }
 
 UnaryExpr::UnaryExpr(TokenType op, std::shared_ptr<Expr const> const &expr)
-: op(op), expr(expr)
+: op_(op), expr_(expr)
 {
 }
 
@@ -369,14 +375,14 @@ UnaryExpr::toStream(std::ostream &s) const
 TokenType
 UnaryExpr::getOperator() const
 {
-    return op;
+    return op_;
 }
 
 Expr const &
 UnaryExpr::getExpr() const
 {
-    assert(expr);
-    return *expr;
+    assert(expr_);
+    return *expr_;
 }
 
 CompoundStmt::CompoundStmt()
@@ -616,6 +622,6 @@ DefStmt::addArgument(std::string const &name)
 std::shared_ptr<Expr const> const &
 LambdaExpr::getExprPtr() const
 {
-    assert(expr);
-    return expr;
+    assert(expr_);
+    return expr_;
 }

--- a/src/AST.cc
+++ b/src/AST.cc
@@ -58,15 +58,15 @@ StringExpr::toStream(std::ostream &s) const
     s << '"' << getValue() << '"';
 }
 
-DecimalExpr::DecimalExpr(double v)
-: value(v)
+DecimalExpr::DecimalExpr(double value)
+: _value(value)
 {
 }
 
 double
 DecimalExpr::getValue() const
 {
-    return value;
+    return _value;
 }
 
 void
@@ -75,15 +75,15 @@ DecimalExpr::toStream(std::ostream &s) const
     s << getValue() << 'd';
 }
 
-IntegerExpr::IntegerExpr(long v)
-: value(v)
+IntegerExpr::IntegerExpr(long value)
+: _value(value)
 {
 }
 
 int64_t
 IntegerExpr::getValue() const
 {
-    return value;
+    return _value;
 }
 
 void
@@ -93,14 +93,14 @@ IntegerExpr::toStream(std::ostream &s) const
 }
 
 IdentExpr::IdentExpr(std::string const &name)
-: name_(name)
+: _name(name)
 {
 }
 
 std::string const &
 IdentExpr::getName() const
 {
-    return name_;
+    return _name;
 }
 
 void
@@ -110,7 +110,7 @@ IdentExpr::toStream(std::ostream &s) const
 }
 
 LambdaExpr::LambdaExpr(std::shared_ptr<Expr> const &expr)
-: expr_(expr)
+: _expr(expr)
 {
 }
 
@@ -123,26 +123,26 @@ LambdaExpr::args() const
 void
 LambdaExpr::addArgument(std::string const &name)
 {
-    args_.emplace_back(name);
+    _args.emplace_back(name);
 }
 
 std::string const *
 LambdaExpr::arg_begin() const
 {
-    return args_.data();
+    return _args.data();
 }
 
 std::string const *
 LambdaExpr::arg_end() const
 {
-    return args_.data() + args_.size();
+    return _args.data() + _args.size();
 }
 
 Expr const &
 LambdaExpr::getExpr() const
 {
-    assert(expr_);
-    return *expr_;
+    assert(_expr);
+    return *_expr;
 }
 
 void
@@ -167,7 +167,7 @@ BinaryExpr::BinaryExpr(
         std::shared_ptr<Expr const> const &lhs,
         TokenType op,
         std::shared_ptr<Expr const> const &rhs)
-: lhs_(lhs), rhs_(rhs), op_(op)
+: _lhs(lhs), _rhs(rhs), _operator(op)
 {
 }
 
@@ -182,21 +182,21 @@ BinaryExpr::toStream(std::ostream &s) const
 Expr const &
 BinaryExpr::getLeftOperand() const
 {
-    assert(lhs_);
-    return *lhs_;
+    assert(_lhs);
+    return *_lhs;
 }
 
 Expr const &
 BinaryExpr::getRightOperand() const
 {
-    assert(rhs_);
-    return *rhs_;
+    assert(_rhs);
+    return *_rhs;
 }
 
 TokenType
 BinaryExpr::getOperator() const
 {
-    return op_;
+    return _operator;
 }
 
 void
@@ -270,38 +270,38 @@ operator<< (std::ostream & s, Stmt const & stmt)
 }
 
 StringExpr::StringExpr(std::string const &value)
-: value_(value)
+: _value(value)
 {
 }
 
 std::string const &
 StringExpr::getValue() const
 {
-    return value_;
+    return _value;
 }
 
 CallExpr::CallExpr(std::shared_ptr<Expr> const &callee)
-: callee_(callee)
+: _callee(callee)
 {
 }
 
 Expr const &
 CallExpr::getCallee() const
 {
-    assert(callee_);
-    return *callee_;
+    assert(_callee);
+    return *_callee;
 }
 
 std::vector<std::shared_ptr<Expr const>> const &
 CallExpr::getArguments() const
 {
-    return arguments;
+    return _arguments;
 }
 
 void
 CallExpr::addArgument(std::shared_ptr<Expr const> argument)
 {
-    arguments.emplace_back(argument);
+    _arguments.emplace_back(argument);
 }
 
 TupleExpr::TupleExpr()
@@ -314,7 +314,7 @@ TupleExpr::toStream(std::ostream &s) const
     s << "(";
 
     int i = 0;
-    for (auto const &member : members) {
+    for (auto const &member : _members) {
         if (i > 0) {
             s << ", ";
         }
@@ -323,7 +323,7 @@ TupleExpr::toStream(std::ostream &s) const
         i += 1;
     }
 
-    if (members.size() == 1) {
+    if (_members.size() == 1) {
         s << ",";
     }
 
@@ -333,17 +333,17 @@ TupleExpr::toStream(std::ostream &s) const
 std::vector<std::shared_ptr<Expr const>> const &
 TupleExpr::getMembers() const
 {
-    return members;
+    return _members;
 }
 
 void
 TupleExpr::addMember(std::shared_ptr<Expr> member)
 {
-    members.emplace_back(member);
+    _members.emplace_back(member);
 }
 
 TokenExpr::TokenExpr(TokenType type)
-: tokenType(type)
+: _tokenType(type)
 {
 }
 
@@ -356,11 +356,11 @@ TokenExpr::toStream(std::ostream &s) const
 TokenType
 TokenExpr::getTokenType() const
 {
-    return tokenType;
+    return _tokenType;
 }
 
 UnaryExpr::UnaryExpr(TokenType op, std::shared_ptr<Expr const> const &expr)
-: op_(op), expr_(expr)
+: _operator(op), _expr(expr)
 {
 }
 
@@ -375,14 +375,14 @@ UnaryExpr::toStream(std::ostream &s) const
 TokenType
 UnaryExpr::getOperator() const
 {
-    return op_;
+    return _operator;
 }
 
 Expr const &
 UnaryExpr::getExpr() const
 {
-    assert(expr_);
-    return *expr_;
+    assert(_expr);
+    return *_expr;
 }
 
 CompoundStmt::CompoundStmt()
@@ -400,13 +400,13 @@ CompoundStmt::toStream(std::ostream &s) const
 std::vector<std::shared_ptr<Stmt const>> const &
 CompoundStmt::getStatements() const
 {
-    return statements;
+    return _statements;
 }
 
 void
 CompoundStmt::addStatement(std::shared_ptr<Stmt const> const &stmt)
 {
-    statements.push_back(stmt);
+    _statements.push_back(stmt);
 }
 
 PassStmt::PassStmt()
@@ -423,13 +423,13 @@ ConditionalStmt::ConditionalStmt(
         std::shared_ptr<Expr const> const &condition,
         std::shared_ptr<Stmt const> const &thenBranch,
         std::shared_ptr<Stmt const> const &elseBranch)
-: condition(condition),
-  thenBranch(thenBranch),
-  elseBranch(elseBranch)
+: _condition(condition),
+  _thenBranch(thenBranch),
+  _elseBranch(elseBranch)
 {
-    assert(this->condition);
-    assert(this->thenBranch);
-    assert(this->elseBranch);
+    assert(this->_condition);
+    assert(this->_thenBranch);
+    assert(this->_elseBranch);
 }
 
 void
@@ -452,61 +452,61 @@ ConditionalStmt::toStream(std::ostream &s) const
 Expr const &
 ConditionalStmt::getCondition() const
 {
-    assert(condition);
-    return *condition;
+    assert(_condition);
+    return *_condition;
 }
 
 Stmt const &
 ConditionalStmt::getThenBranch() const
 {
-    assert(thenBranch);
-    return *thenBranch;
+    assert(_thenBranch);
+    return *_thenBranch;
 }
 
 Stmt const &
 ConditionalStmt::getElseBranch() const
 {
-    assert(elseBranch);
-    return *elseBranch;
+    assert(_elseBranch);
+    return *_elseBranch;
 }
 
 ExprStmt::ExprStmt(std::shared_ptr<Expr const> const &expr)
-: expr(expr)
+: _expr(expr)
 {
 }
 
 Expr const &
 ExprStmt::getExpr() const
 {
-    assert(expr);
-    return *expr;
+    assert(_expr);
+    return *_expr;
 }
 
 DefStmt::DefStmt(
         std::string const &name,
         std::shared_ptr<Stmt const> const &body)
-: name(name),
-  body(body)
+: _name(name),
+  _body(body)
 {
 }
 
 ReturnStmt::ReturnStmt(std::shared_ptr<Expr const> const &expr)
-: expr(expr)
+: _expr(expr)
 {
 }
 
 Expr const &
 ReturnStmt::getExpr() const
 {
-    assert(expr);
-    return *expr;
+    assert(_expr);
+    return *_expr;
 }
 
 std::shared_ptr<Expr const> const &
 ReturnStmt::getExprPtr() const
 {
-    assert(expr);
-    return expr;
+    assert(_expr);
+    return _expr;
 }
 
 Expr::Expr() = default;
@@ -516,8 +516,8 @@ Stmt::Stmt() = default;
 WhileStmt::WhileStmt(
         std::shared_ptr<Expr const> const &condition,
         std::shared_ptr<Stmt const> const &body)
-: condition(condition),
-  body(body)
+: _condition(condition),
+  _body(body)
 {
 }
 
@@ -531,15 +531,15 @@ WhileStmt::toStream(std::ostream &s) const
 Expr const &
 WhileStmt::getCondition() const
 {
-    assert(condition);
-    return *condition;
+    assert(_condition);
+    return *_condition;
 }
 
 Stmt const &
 WhileStmt::getBody() const
 {
-    assert(body);
-    return *body;
+    assert(_body);
+    return *_body;
 }
 
 void
@@ -557,47 +557,47 @@ ContinueStmt::toStream(std::ostream &s) const
 AssignStmt::AssignStmt(
         std::string const &name,
         std::shared_ptr<Expr const> const &value)
-: name(name),
-  value(value)
+: _name(name),
+  _value(value)
 {
 }
 
 std::string const &
 AssignStmt::getName() const
 {
-    return name;
+    return _name;
 }
 
 Expr const &
 AssignStmt::getValue() const
 {
-    assert(value);
-    return *value;
+    assert(_value);
+    return *_value;
 }
 
 std::shared_ptr<Expr const> const &
 AssignStmt::getValuePtr() const
 {
-    assert(value);
-    return value;
+    assert(_value);
+    return _value;
 }
 
 std::string const &
 DefStmt::getName() const
 {
-    return name;
+    return _name;
 }
 
 std::string const *
 DefStmt::arg_begin() const
 {
-    return args_.data();
+    return _args.data();
 }
 
 std::string const *
 DefStmt::arg_end() const
 {
-    return args_.data() + args_.size();
+    return _args.data() + _args.size();
 }
 
 ArgNamesIter
@@ -609,19 +609,19 @@ DefStmt::args() const
 Stmt const &
 DefStmt::getBody() const
 {
-    assert(body);
-    return *body;
+    assert(_body);
+    return *_body;
 }
 
 void
 DefStmt::addArgument(std::string const &name)
 {
-    args_.emplace_back(name);
+    _args.emplace_back(name);
 }
 
 std::shared_ptr<Expr const> const &
 LambdaExpr::getExprPtr() const
 {
-    assert(expr_);
-    return expr_;
+    assert(_expr);
+    return _expr;
 }

--- a/src/Compiler.cc
+++ b/src/Compiler.cc
@@ -9,7 +9,7 @@ using std::cerr;
 using std::endl;
 
 Compiler::Compiler() noexcept
-: impl(std::make_unique<CompilerImpl>())
+: _impl(std::make_unique<CompilerImpl>())
 {
 }
 
@@ -18,14 +18,14 @@ Compiler::~Compiler() = default;
 llvm::DataLayout const &
 Compiler::getDataLayout() const
 {
-    return impl->getDataLayout();
+    return _impl->getDataLayout();
 }
 
 void
 Compiler::addAndRunModule(std::unique_ptr<llvm::Module> module)
 {
-    impl->addModule(std::move(module));
-    llvm::JITSymbol moduleBody = impl->findSymbol("__body__");
+    _impl->addModule(std::move(module));
+    llvm::JITSymbol moduleBody = _impl->findSymbol("__body__");
 
     auto expectedTargetAddress = moduleBody.getAddress();
 

--- a/src/CompilerImpl.cc
+++ b/src/CompilerImpl.cc
@@ -1,8 +1,13 @@
-#include "CompilerImpl.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/Mangler.h>
+#pragma GCC diagnostic pop
+
+#include "CompilerImpl.h"
 #include <algorithm>
 #include <sstream>
 using namespace llvmPy;

--- a/src/CompilerImpl.h
+++ b/src/CompilerImpl.h
@@ -1,11 +1,17 @@
 #pragma once
-#include <memory>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include "llvm/ExecutionEngine/Orc/LambdaResolver.h"
+#pragma GCC diagnostic pop
+
+#include <memory>
 #include <vector>
 
 #ifdef __cplusplus

--- a/src/Emitter.cc
+++ b/src/Emitter.cc
@@ -47,10 +47,10 @@ static struct {
 } tags;
 
 Emitter::Emitter(Compiler &c) noexcept
-: dl(c.getDataLayout()),
-  ctx(c.getContext()),
-  ir(ctx),
-  types(ctx, dl)
+: _dl(c.getDataLayout()),
+  _ctx(c.getContext()),
+  _ir(_ctx),
+  _types(_ctx, _dl)
 {
 }
 
@@ -59,9 +59,9 @@ Emitter::createModule(
         std::string const &name,
         Stmt const &stmt)
 {
-    auto *module = new llvm::Module(name, ctx);
-    module->setDataLayout(dl);
-    RTModule *rtModule = new RTModule(name, module, types);
+    auto *module = new llvm::Module(name, _ctx);
+    module->setDataLayout(_dl);
+    RTModule *rtModule = new RTModule(name, module, _types);
 
     createFunction(
             "__body__",
@@ -115,19 +115,19 @@ Emitter::emit(RTScope &scope, CallExpr const &call)
     if (auto *lhsIdent = callee.cast<IdentExpr>()) {
         if (lhsIdent->getName() == "print") {
             llvm::Value *arg = emit(scope, *args[0]);
-            return ir.CreateCall(mod.llvmPy_print(), { arg });
+            return _ir.CreateCall(mod.llvmPy_print(), { arg });
         } else if (lhsIdent->getName() == "len") {
             llvm::Value *arg = emit(scope, *args[0]);
-            return ir.CreateCall(mod.llvmPy_len(), { arg });
+            return _ir.CreateCall(mod.llvmPy_len(), { arg });
         } else if (lhsIdent->getName() == "str") {
             llvm::Value *arg = emit(scope, *args[0]);
-            return ir.CreateCall(mod.llvmPy_str(), { arg });
+            return _ir.CreateCall(mod.llvmPy_str(), { arg });
         } else if (lhsIdent->getName() == "int") {
             llvm::Value *arg = emit(scope, *args[0]);
-            return ir.CreateCall(mod.llvmPy_int(), { arg });
+            return _ir.CreateCall(mod.llvmPy_int(), { arg });
         } else if (lhsIdent->getName() == "bool") {
             llvm::Value *arg = emit(scope, *args[0]);
-            return ir.CreateCall(mod.llvmPy_bool(), { arg });
+            return _ir.CreateCall(mod.llvmPy_bool(), { arg });
         }
     }
 
@@ -144,24 +144,24 @@ Emitter::emit(RTScope &scope, CallExpr const &call)
     }
 
     // Call frame pointer.
-    auto *callFrameAlloca = ir.CreateAlloca(
-            types.FramePtr, nullptr, tags.CallFrame);
+    auto *callFrameAlloca = _ir.CreateAlloca(
+            _types.FramePtr, nullptr, tags.CallFrame);
 
     // Count of positional arguments.
-    llvm::Value *np = llvm::ConstantInt::get(types.PyIntValue, argCount);
+    llvm::Value *np = llvm::ConstantInt::get(_types.PyIntValue, argCount);
 
-    llvm::CallInst *inst = ir.CreateCall(
+    llvm::CallInst *inst = _ir.CreateCall(
             mod.llvmPy_fchk(),
             { callFrameAlloca, lhs, np },
             tags.FuncPtr);
 
     argSlots[0] = callFrameAlloca;
 
-    llvm::Value *funcBitCast = ir.CreateBitCast(
+    llvm::Value *funcBitCast = _ir.CreateBitCast(
             inst,
-            types.getPtr(types.getOpaqueFunc(argCount)));
+            _types.getPtr(_types.getOpaqueFunc(argCount)));
 
-    return ir.CreateCall(funcBitCast, argSlots, tags.RetVal);
+    return _ir.CreateCall(funcBitCast, argSlots, tags.RetVal);
 }
 
 llvm::Value *
@@ -169,7 +169,7 @@ Emitter::emit(RTScope &scope, IntegerExpr const &expr)
 {
     RTModule &mod = scope.getModule();
     auto *global = mod.llvmPy_PyInt(expr.getValue());
-    return ir.CreateLoad(global, global->getName());
+    return _ir.CreateLoad(global, global->getName());
 }
 
 llvm::Value *
@@ -188,7 +188,7 @@ Emitter::emit(RTScope &scope, IdentExpr const &ident)
     }
 
     auto *gep = findLexicalSlotGEP(name, scope, scope.getInnerFramePtrPtr());
-    return ir.CreateLoad(gep);
+    return _ir.CreateLoad(gep);
 }
 
 llvm::Value *
@@ -199,7 +199,7 @@ Emitter::emit(RTScope &scope, LambdaExpr const &lambda)
     ReturnStmt returnStmt(lambda.getExprPtr());
 
     // TODO: XXX?
-    auto *insertBlock = ir.GetInsertBlock();
+    auto *insertBlock = _ir.GetInsertBlock();
 
     auto *function = createFunction(
             tags.Lambda,
@@ -207,19 +207,19 @@ Emitter::emit(RTScope &scope, LambdaExpr const &lambda)
             returnStmt,
             lambda.args());
 
-    ir.SetInsertPoint(insertBlock);
+    _ir.SetInsertPoint(insertBlock);
 
     llvm::Value *innerFramePtrBitCast =
-            ir.CreateBitCast(
+            _ir.CreateBitCast(
                     scope.getInnerFramePtr(),
-                    types.FramePtr);
+                    _types.FramePtr);
 
     llvm::Value *functionPtrBitCast =
-            ir.CreateBitCast(
+            _ir.CreateBitCast(
                     function,
-                    types.i8Ptr);
+                    _types.i8Ptr);
 
-    return ir.CreateCall(
+    return _ir.CreateCall(
             mod.llvmPy_func(),
             { innerFramePtrBitCast,
               functionPtrBitCast });
@@ -230,7 +230,7 @@ Emitter::emit(RTScope &scope, StringExpr const &lit)
 {
     RTModule &mod = scope.getModule();
     auto *global = mod.llvmPy_PyStr(lit.getValue());
-    return ir.CreateLoad(global, global->getName());
+    return _ir.CreateLoad(global, global->getName());
 }
 
 llvm::Value *
@@ -255,7 +255,7 @@ Emitter::emit(RTScope &scope, BinaryExpr const &expr)
     default: return nullptr;
     }
 
-    return ir.CreateCall(f, { lhs, rhs });
+    return _ir.CreateCall(f, { lhs, rhs });
 }
 
 llvm::Function *
@@ -272,7 +272,7 @@ Emitter::createFunction(
     if (outerScope.getInnerFramePtrPtr()) {
         innerScope->setOuterFrameType(outerScope.getInnerFrameType());
     } else {
-        innerScope->setOuterFrameType(types.Frame);
+        innerScope->setOuterFrameType(_types.Frame);
     }
 
     std::set<std::string> slotNames;
@@ -288,14 +288,14 @@ Emitter::createFunction(
     gatherSlotNames(stmt, slotNames);
 
     innerScope->setInnerFrameType(
-            types.getFuncFrame(
+            _types.getFuncFrame(
                     name,
                     innerScope->getOuterFrameType(),
                     slotNames.size()));
 
     llvm::Function *function =
             llvm::Function::Create(
-                    types.getFunc(
+                    _types.getFunc(
                             name,
                             innerScope->getOuterFrameType(),
                             argCount),
@@ -327,42 +327,42 @@ Emitter::createFunction(
     }
 
     // Create function body.
-    auto *entry = llvm::BasicBlock::Create(ctx, "", function);
-    ir.SetInsertPoint(entry);
+    auto *entry = llvm::BasicBlock::Create(_ctx, "", function);
+    _ir.SetInsertPoint(entry);
 
     // Generate the frame for variables to be potentially lifted onto the
     // heap by a closure.
 
-    auto *frameAlloca = ir.CreateAlloca(
+    auto *frameAlloca = _ir.CreateAlloca(
             innerScope->getInnerFrameType(),
             nullptr,
             tags.InnerFrame);
 
     innerScope->setInnerFramePtr(frameAlloca);
 
-    auto *frameSelfPtrPtr = ir.CreateGEP(
+    auto *frameSelfPtrPtr = _ir.CreateGEP(
             frameAlloca,
-            { types.getInt64(0),
-              types.getInt32(Frame::SelfIndex) });
+            { _types.getInt64(0),
+              _types.getInt32(Frame::SelfIndex) });
 
     innerScope->setInnerFramePtrPtr(frameSelfPtrPtr);
 
-    auto *frameOuterPtrPtr = ir.CreateGEP(
+    auto *frameOuterPtrPtr = _ir.CreateGEP(
             frameAlloca,
-            { types.getInt64(0),
-              types.getInt32(Frame::OuterIndex) });
+            { _types.getInt64(0),
+              _types.getInt32(Frame::OuterIndex) });
 
-    ir.CreateStore(frameAlloca, frameSelfPtrPtr);
+    _ir.CreateStore(frameAlloca, frameSelfPtrPtr);
 
-    auto *outerFramePtr = ir.CreateLoad(
+    auto *outerFramePtr = _ir.CreateLoad(
             outerFramePtrPtrArg, tags.OuterFrame);
 
-    ir.CreateStore(outerFramePtr, frameOuterPtrPtr);
+    _ir.CreateStore(outerFramePtr, frameOuterPtrPtr);
 
     // TODO: Zero-initialize slots with llvm.memset or something.
 
     function->setPrefixData(
-            types.getInt64(reinterpret_cast<int64_t>(innerScope)));
+            _types.getInt64(reinterpret_cast<int64_t>(innerScope)));
 
     for (auto const &slotName : slotNames) {
         innerScope->declareSlot(slotName);
@@ -379,25 +379,25 @@ Emitter::createFunction(
             assert(innerScope->hasSlot(ident));
             auto slotIndex = innerScope->getSlotIndex(ident);
 
-            auto *argVarPtr = ir.CreateGEP(
+            auto *argVarPtr = _ir.CreateGEP(
                     frameAlloca,
-                    { types.getInt64(0),
-                      types.getInt32(Frame::VarsIndex),
-                      types.getInt64(static_cast<int64_t>(slotIndex)) },
+                    { _types.getInt64(0),
+                      _types.getInt32(Frame::VarsIndex),
+                      _types.getInt64(static_cast<int64_t>(slotIndex)) },
                     tags.Var + "_" + ident);
 
-            ir.CreateStore(&arg, argVarPtr);
+            _ir.CreateStore(&arg, argVarPtr);
         }
 
         iArg++;
     }
 
-    ir.SetInsertPoint(entry);
+    _ir.SetInsertPoint(entry);
 
     emitStatement(*function, *innerScope, stmt, nullptr);
 
     if (!lastInstructionWasTerminator()) {
-        ir.CreateRet(mod.llvmPy_None());
+        _ir.CreateRet(mod.llvmPy_None());
     }
 
     llvm::verifyFunction(*function);
@@ -420,34 +420,34 @@ Emitter::emitCondStmt(
     size_t condIndex = scope.getNextCondStmtIndex();
     std::string suffix = "." + std::to_string(condIndex);
 
-    auto *ifBB = llvm::BasicBlock::Create(ctx, tags.If + suffix);
-    auto *thenBB = llvm::BasicBlock::Create(ctx, tags.Then + suffix);
-    auto *elseBB = llvm::BasicBlock::Create(ctx, tags.Else + suffix);
-    auto *endifBB = llvm::BasicBlock::Create(ctx, tags.Endif + suffix);
+    auto *ifBB = llvm::BasicBlock::Create(_ctx, tags.If + suffix);
+    auto *thenBB = llvm::BasicBlock::Create(_ctx, tags.Then + suffix);
+    auto *elseBB = llvm::BasicBlock::Create(_ctx, tags.Else + suffix);
+    auto *endifBB = llvm::BasicBlock::Create(_ctx, tags.Endif + suffix);
 
-    ir.CreateBr(ifBB);
+    _ir.CreateBr(ifBB);
     ifBB->insertInto(&function);
-    ir.SetInsertPoint(ifBB);
+    _ir.SetInsertPoint(ifBB);
     auto *ifExprValue = emit(scope, cond.getCondition());
-    auto *truthyValue = ir.CreateCall(mod.llvmPy_truthy(), { ifExprValue });
-    ir.CreateCondBr(truthyValue, thenBB, elseBB);
+    auto *truthyValue = _ir.CreateCall(mod.llvmPy_truthy(), { ifExprValue });
+    _ir.CreateCondBr(truthyValue, thenBB, elseBB);
 
     thenBB->insertInto(&function);
-    ir.SetInsertPoint(thenBB);
+    _ir.SetInsertPoint(thenBB);
     emitStatement(function, scope, cond.getThenBranch(), loop);
     if (!lastInstructionWasTerminator()) {
-        ir.CreateBr(endifBB);
+        _ir.CreateBr(endifBB);
     }
 
     elseBB->insertInto(&function);
-    ir.SetInsertPoint(elseBB);
+    _ir.SetInsertPoint(elseBB);
     emitStatement(function, scope, cond.getElseBranch(), loop);
     if (!lastInstructionWasTerminator()) {
-        ir.CreateBr(endifBB);
+        _ir.CreateBr(endifBB);
     }
 
     endifBB->insertInto(&function);
-    ir.SetInsertPoint(endifBB);
+    _ir.SetInsertPoint(endifBB);
 }
 
 void
@@ -470,7 +470,7 @@ Emitter::emitStatement(
         emit(scope, expr->getExpr());
     } else if (auto *ret = stmt.cast<ReturnStmt>()) {
         auto *value = emit(scope, ret->getExpr());
-        ir.CreateRet(value);
+        _ir.CreateRet(value);
     } else if (auto *def = stmt.cast<DefStmt>()) {
         emitDefStmt(function, scope, *def);
     } else if (stmt.isa<PassStmt>()) {
@@ -482,7 +482,7 @@ Emitter::emitStatement(
         // may invalidate the existing stack pointer.
         auto *value = emit(scope, assign->getValue());
         auto *slotGEP = findLexicalSlotGEP(assign->getName(), scope);
-        ir.CreateStore(value, slotGEP);
+        _ir.CreateStore(value, slotGEP);
     } else if (auto *while_ = stmt.cast<WhileStmt>()) {
         emitWhileStmt(function, scope, *while_);
     } else if (stmt.isa<BreakStmt>()) {
@@ -505,49 +505,49 @@ Emitter::emitWhileStmt(
     auto whileIndex = scope.getNextWhileStmtIndex();
     std::string suffix = "." + std::to_string(whileIndex);
 
-    auto *condBB = llvm::BasicBlock::Create(ctx, tags.While + suffix);
-    auto *loopBB = llvm::BasicBlock::Create(ctx, tags.Loop + suffix);
-    auto *endwhileBB = llvm::BasicBlock::Create(ctx, tags.Endwhile + suffix);
+    auto *condBB = llvm::BasicBlock::Create(_ctx, tags.While + suffix);
+    auto *loopBB = llvm::BasicBlock::Create(_ctx, tags.Loop + suffix);
+    auto *endwhileBB = llvm::BasicBlock::Create(_ctx, tags.Endwhile + suffix);
 
     Loop loop = { .cond = condBB, .end = endwhileBB };
 
-    ir.CreateBr(condBB);
+    _ir.CreateBr(condBB);
 
     condBB->insertInto(&function);
-    ir.SetInsertPoint(condBB);
+    _ir.SetInsertPoint(condBB);
     auto *condExprValue = emit(scope, stmt.getCondition());
-    auto *truthyValue = ir.CreateCall(mod.llvmPy_truthy(), { condExprValue });
-    ir.CreateCondBr(truthyValue, loopBB, endwhileBB);
+    auto *truthyValue = _ir.CreateCall(mod.llvmPy_truthy(), { condExprValue });
+    _ir.CreateCondBr(truthyValue, loopBB, endwhileBB);
 
     loopBB->insertInto(&function);
-    ir.SetInsertPoint(loopBB);
+    _ir.SetInsertPoint(loopBB);
     emitStatement(function, scope, stmt.getBody(), &loop);
     if (!lastInstructionWasTerminator()) {
-        ir.CreateBr(condBB);
+        _ir.CreateBr(condBB);
     }
 
     endwhileBB->insertInto(&function);
-    ir.SetInsertPoint(endwhileBB);
+    _ir.SetInsertPoint(endwhileBB);
 }
 
 void
 Emitter::emitBreakStmt(Emitter::Loop const *loop)
 {
     assert(loop && loop->end);
-    ir.CreateBr(loop->end);
+    _ir.CreateBr(loop->end);
 }
 
 void
 Emitter::emitContinueStmt(Emitter::Loop const *loop)
 {
     assert(loop && loop->cond);
-    ir.CreateBr(loop->cond);
+    _ir.CreateBr(loop->cond);
 }
 
 bool
 Emitter::lastInstructionWasTerminator() const
 {
-    return ir.GetInsertBlock()->getTerminator() != nullptr;
+    return _ir.GetInsertBlock()->getTerminator() != nullptr;
 }
 
 void
@@ -578,7 +578,7 @@ Emitter::emitDefStmt(
     RTModule &mod = scope.getModule();
 
     // TODO: XXX?
-    auto *insertBlock = ir.GetInsertBlock();
+    auto *insertBlock = _ir.GetInsertBlock();
 
     auto *function = createFunction(
             def.getName(),
@@ -586,26 +586,26 @@ Emitter::emitDefStmt(
             def.getBody(),
             def.args());
 
-    ir.SetInsertPoint(insertBlock);
+    _ir.SetInsertPoint(insertBlock);
 
     llvm::Value *innerFramePtrBitCast =
-            ir.CreateBitCast(
+            _ir.CreateBitCast(
                     scope.getInnerFramePtr(),
-                    types.FramePtr);
+                    _types.FramePtr);
 
     llvm::Value *functionPtrBitCast =
-            ir.CreateBitCast(
+            _ir.CreateBitCast(
                     function,
-                    types.i8Ptr);
+                    _types.i8Ptr);
 
-    auto *value = ir.CreateCall(
+    auto *value = _ir.CreateCall(
             mod.llvmPy_func(),
             { innerFramePtrBitCast,
               functionPtrBitCast });
 
     auto *gep = findLexicalSlotGEP(def.getName(), scope);
 
-    ir.CreateStore(value, gep);
+    _ir.CreateStore(value, gep);
 }
 
 llvm::Value *
@@ -644,25 +644,25 @@ Emitter::findLexicalSlotGEP(
 
         assert(index >= 0); // Later -1 could mean it's not a frame value.
 
-        auto *framePtr = ir.CreateLoad(framePtrPtr);
+        auto *framePtr = _ir.CreateLoad(framePtrPtr);
 
-        auto *slotGEP = ir.CreateGEP(
+        auto *slotGEP = _ir.CreateGEP(
                 framePtr,
-                { types.getInt64(0),
-                  types.getInt32(Frame::VarsIndex),
-                  types.getInt64(index) },
+                { _types.getInt64(0),
+                  _types.getInt32(Frame::VarsIndex),
+                  _types.getInt64(index) },
                 tags.Var + "." + name);
 
         return slotGEP;
 
     } else if (scope.hasParent()) {
 
-        auto *framePtr = ir.CreateLoad(framePtrPtr);
+        auto *framePtr = _ir.CreateLoad(framePtrPtr);
 
-        auto *outerFramePtrPtr = ir.CreateGEP(
+        auto *outerFramePtrPtr = _ir.CreateGEP(
                 framePtr,
-                { types.getInt64(0),
-                  types.getInt32(Frame::OuterIndex) });
+                { _types.getInt64(0),
+                  _types.getInt32(Frame::OuterIndex) });
 
         auto *result = findLexicalSlotGEP(
                 name,

--- a/src/Emitter.cc
+++ b/src/Emitter.cc
@@ -612,16 +612,19 @@ llvm::Value *
 Emitter::emit(RTScope &scope, UnaryExpr const &unary)
 {
     if (auto *integer = unary.getExpr().cast<IntegerExpr>()) {
-        auto const op = unary.getOperator();
         int64_t sign = 1;
 
-        if (op == tok_sub) {
+        switch (unary.getOperator()) {
+        case tok_sub:
             sign = -1;
-        }
-
-        if (op == tok_add) {
+            [[clang::fallthrough]];
+        case tok_add: {
             IntegerExpr expr(sign * integer->getValue());
             return emit(scope, expr);
+        }
+
+        default:
+            break;
         }
     }
 

--- a/src/Instr.cc
+++ b/src/Instr.cc
@@ -80,7 +80,7 @@ Types::getPtr(llvm::Type *type) const
 }
 
 llvm::FunctionType *
-Types::getOpaqueFunc(int N) const
+Types::getOpaqueFunc(size_t N) const
 {
     std::vector<llvm::Type *> argTypes;
     argTypes.push_back(FramePtrPtr);
@@ -96,7 +96,7 @@ llvm::FunctionType *
 Types::getFunc(
         std::string const &name,
         llvm::StructType *outer,
-        int N) const
+        size_t N) const
 {
     std::vector<llvm::Type *> argTypes;
     argTypes.push_back(getPtr(getPtr(outer)));
@@ -112,7 +112,7 @@ llvm::StructType *
 Types::getFuncFrame(
         std::string const &name,
         llvm::StructType *outer,
-        int N) const
+        size_t N) const
 {
     std::string frameName = "Frame." + name;
 

--- a/src/Lexer.cc
+++ b/src/Lexer.cc
@@ -25,19 +25,19 @@ buildKeywordMap()
 }
 
 Lexer::Lexer(std::istream & stream)
-: stream(stream), keywords(buildKeywordMap())
+: _stream(stream), _keywords(buildKeywordMap())
 {
-    ibuf = 0;
-    ilast = -1;
-    line = 0;
-    col = 0;
-    error = "";
+    _ibuf = 0;
+    _ilast = -1;
+    _line = 0;
+    _col = 0;
+    _error = "";
 }
 
 bool
 Lexer::tokenize(std::vector<Token> & out)
 {
-    tokens.clear();
+    _tokens.clear();
 
     bool newline = true;
     bool comment = false;
@@ -83,7 +83,7 @@ Lexer::tokenize(std::vector<Token> & out)
         if (ident()) continue;
     }
 
-    out = std::move(tokens);
+    out = std::move(_tokens);
     return true;
 }
 
@@ -114,7 +114,7 @@ Lexer::getError()
 bool
 Lexer::isEof()
 {
-    return ch == (char) eof || stream.eof();
+    return _ch == (char) eof || _stream.eof();
 }
 
 void
@@ -122,81 +122,81 @@ Lexer::add(Token token)
 {
     if (token.getTokenType() == tok_eol) {
         // Ignore empty lines at start of file.
-        if (tokens.empty()) return;
+        if (_tokens.empty()) return;
 
         // Ignore empty lines in the middle of the file.
-        if (tokens.back().getTokenType() == tok_eol) return;
+        if (_tokens.back().getTokenType() == tok_eol) return;
     } else if (token.getTokenType() == tok_eof) {
         // Ignore empty lines at end of file.
-        if (!tokens.empty() && tokens.back().getTokenType() == tok_eol) {
-            tokens.pop_back();
+        if (!_tokens.empty() && _tokens.back().getTokenType() == tok_eol) {
+            _tokens.pop_back();
         }
     }
 
-    tokens.emplace_back(std::move(token));
+    _tokens.emplace_back(std::move(token));
 }
 
 void
 Lexer::next()
 {
-    if (ibuf < ilast - 1) {
-        ch = buf[++ibuf];
-    } else if (ibuf == ilast - 1) {
-        ++ibuf;
-        ch = (char) stream.peek();
-        ilast = -1;
+    if (_ibuf < _ilast - 1) {
+        _ch = _buf[++_ibuf];
+    } else if (_ibuf == _ilast - 1) {
+        ++_ibuf;
+        _ch = (char) _stream.peek();
+        _ilast = -1;
     } else {
-        if (ilast > -1) {
+        if (_ilast > -1) {
             // Don't touch the buffer unless a state was pushed.
             // Very long tokens (e.g. strings) will have their own
             // buffering mechanism.
-            buf[ibuf++] = ch;
+            _buf[_ibuf++] = _ch;
         }
 
-        stream.get();
-        ch = (char) stream.peek();
+        _stream.get();
+        _ch = (char) _stream.peek();
     }
 }
 
 void
 Lexer::next(std::stringstream & ss)
 {
-    ss << ch;
+    ss << _ch;
     next();
 }
 
 void
 Lexer::reset()
 {
-    ibuf = 0;
-    ilast = -1;
-    ch = (char) stream.peek();
+    _ibuf = 0;
+    _ilast = -1;
+    _ch = (char) _stream.peek();
 }
 
 void
 Lexer::push()
 {
-    ilast = ibuf;
+    _ilast = _ibuf;
 }
 
 void
 Lexer::pop()
 {
-    auto tmp = ibuf;
-    ibuf = ilast;
-    ilast = tmp;
+    auto tmp = _ibuf;
+    _ibuf = _ilast;
+    _ilast = tmp;
 
-    if (ibuf == ilast) {
-        ch = (char) stream.peek();
+    if (_ibuf == _ilast) {
+        _ch = (char) _stream.peek();
     } else {
-        ch = buf[ibuf];
+        _ch = _buf[_ibuf];
     }
 }
 
 bool
 Lexer::is(char c)
 {
-    if (ch == c) {
+    if (_ch == c) {
         next();
         return true;
     } else {
@@ -207,7 +207,7 @@ Lexer::is(char c)
 bool
 Lexer::is(char c, std::stringstream & ss)
 {
-    char cc = ch;
+    char cc = _ch;
 
     if (is(c)) {
         ss << cc;
@@ -220,7 +220,7 @@ Lexer::is(char c, std::stringstream & ss)
 bool
 Lexer::oneof(char const * chs)
 {
-    if (strchr(chs, ch)) {
+    if (strchr(chs, _ch)) {
         next();
         return true;
     } else {
@@ -231,7 +231,7 @@ Lexer::oneof(char const * chs)
 bool
 Lexer::oneof(char const * chs, std::stringstream & ss)
 {
-    char const * ptr = strchr(chs, ch);
+    char const * ptr = strchr(chs, _ch);
     if (ptr) {
         ss << *ptr;
         next();
@@ -244,7 +244,7 @@ Lexer::oneof(char const * chs, std::stringstream & ss)
 bool
 Lexer::oneof(int (* cls)(int))
 {
-    if (cls(ch)) {
+    if (cls(_ch)) {
         next();
         return true;
     }
@@ -255,7 +255,7 @@ Lexer::oneof(int (* cls)(int))
 bool
 Lexer::oneof(int (* cls)(int), std::stringstream & ss)
 {
-    char cc = ch;
+    char cc = _ch;
 
     if (oneof(cls)) {
         ss << cc;
@@ -331,14 +331,14 @@ Lexer::strlit()
 bool
 Lexer::ident()
 {
-    int start = ibuf;
+    int start = _ibuf;
 
     if (!oneof(isalpha) && !is('_'))
         return false;
 
     while (oneof(isalnum) || is('_'));
 
-    auto str = std::make_unique<std::string>(&buf[start], ibuf - start);
+    auto str = std::make_unique<std::string>(&_buf[start], _ibuf - start);
 
     if (auto kw = getKeyword(*str)) {
         add(Token(kw));
@@ -352,7 +352,7 @@ Lexer::ident()
 bool
 Lexer::syntax()
 {
-    char a = ch;
+    char a = _ch;
     if (oneof("<>!=+-*/")) {
         int t;
 
@@ -407,8 +407,8 @@ Lexer::syntax()
 TokenType
 Lexer::getKeyword(std::string const &kw)
 {
-    if (keywords.count(kw)) {
-        return keywords.at(kw);
+    if (_keywords.count(kw)) {
+        return _keywords.at(kw);
     } else {
         return tok_unknown;
     }

--- a/src/Lexer.cc
+++ b/src/Lexer.cc
@@ -5,7 +5,7 @@
 using namespace llvmPy;
 using namespace std;
 
-static constexpr int eof = std::istream::traits_type::eof();
+static constexpr char eof = static_cast<char>(std::istream::traits_type::eof());
 
 static std::map<std::string const, TokenType>
 buildKeywordMap()
@@ -41,7 +41,7 @@ Lexer::tokenize(std::vector<Token> & out)
 
     bool newline = true;
     bool comment = false;
-    int indent = 0;
+    size_t indent = 0;
 
     while (true) {
         reset();
@@ -56,7 +56,7 @@ Lexer::tokenize(std::vector<Token> & out)
             comment = true;
         }
 
-        if (is((char) eof)) {
+        if (is(eof)) {
             add(Token(tok_eof));
             comment = false;
             break;
@@ -114,7 +114,7 @@ Lexer::getError()
 bool
 Lexer::isEof()
 {
-    return _ch == (char) eof || _stream.eof();
+    return _ch == eof || _stream.eof();
 }
 
 void
@@ -143,7 +143,7 @@ Lexer::next()
         _ch = _buf[++_ibuf];
     } else if (_ibuf == _ilast - 1) {
         ++_ibuf;
-        _ch = (char) _stream.peek();
+        _ch = static_cast<char>(_stream.peek());
         _ilast = -1;
     } else {
         if (_ilast > -1) {
@@ -154,7 +154,7 @@ Lexer::next()
         }
 
         _stream.get();
-        _ch = (char) _stream.peek();
+        _ch = static_cast<char>(_stream.peek());
     }
 }
 
@@ -170,7 +170,7 @@ Lexer::reset()
 {
     _ibuf = 0;
     _ilast = -1;
-    _ch = (char) _stream.peek();
+    _ch = static_cast<char>(_stream.peek());
 }
 
 void
@@ -187,7 +187,7 @@ Lexer::pop()
     _ilast = tmp;
 
     if (_ibuf == _ilast) {
-        _ch = (char) _stream.peek();
+        _ch = static_cast<char>(_stream.peek());
     } else {
         _ch = _buf[_ibuf];
     }
@@ -331,7 +331,7 @@ Lexer::strlit()
 bool
 Lexer::ident()
 {
-    int start = _ibuf;
+    ssize_t start = _ibuf;
 
     if (!oneof(isalpha) && !is('_'))
         return false;
@@ -354,7 +354,7 @@ Lexer::syntax()
 {
     char a = _ch;
     if (oneof("<>!=+-*/")) {
-        int t;
+        size_t t;
 
         switch (a) {
         case '<': t = tok_lt; break;

--- a/src/Parser2.cc
+++ b/src/Parser2.cc
@@ -44,7 +44,7 @@ Parser2::fromIter(
 Parser2::Parser2(
         Parser2::TTokenIter &iter,
         Parser2::TTokenIter end)
-: iter(iter), iter_end(end), precedences(initPrecedence())
+: _iter(iter), _iterEnd(end), _precedences(initPrecedence())
 {
 }
 
@@ -387,27 +387,27 @@ Parser2::is_a(TokenType tokenType)
 bool
 Parser2::isEnd()
 {
-    return iter == iter_end || iter->getTokenType() == tok_eof;
+    return _iter == _iterEnd || _iter->getTokenType() == tok_eof;
 }
 
 void
 Parser2::next()
 {
     if (!isEnd()) {
-        iter++;
+        _iter++;
     }
 }
 
 void
 Parser2::back()
 {
-    iter--;
+    _iter--;
 }
 
 Token &
 Parser2::token() const
 {
-    return *iter;
+    return *_iter;
 }
 
 Expr *
@@ -653,8 +653,8 @@ Parser2::findAssignStatement()
 int
 Parser2::getPrecedence(TokenType tokenType) const
 {
-    if (precedences.count(tokenType)) {
-        return precedences.at(tokenType);
+    if (_precedences.count(tokenType)) {
+        return _precedences.at(tokenType);
     } else {
         return 0;
     }

--- a/src/PyObj/PyBool.cc
+++ b/src/PyObj/PyBool.cc
@@ -5,7 +5,7 @@ PyBool llvmPy_True(true);
 PyBool llvmPy_False(false);
 
 PyBool::PyBool(bool value) noexcept
-: value_(value)
+: _value(value)
 {
 
 }
@@ -13,13 +13,13 @@ PyBool::PyBool(bool value) noexcept
 bool
 PyBool::getValue() const
 {
-    return value_;
+    return _value;
 }
 
 std::string
 PyBool::py__str__()
 {
-    return value_ ? "True" : "False";
+    return _value ? "True" : "False";
 }
 
 PyBool &
@@ -31,5 +31,5 @@ PyBool::get(bool value)
 bool
 PyBool::py__bool__()
 {
-    return value_;
+    return _value;
 }

--- a/src/PyObj/PyBool.cc
+++ b/src/PyObj/PyBool.cc
@@ -5,7 +5,7 @@ PyBool llvmPy_True(true);
 PyBool llvmPy_False(false);
 
 PyBool::PyBool(bool value) noexcept
-: value(value)
+: value_(value)
 {
 
 }
@@ -13,13 +13,13 @@ PyBool::PyBool(bool value) noexcept
 bool
 PyBool::getValue() const
 {
-    return value;
+    return value_;
 }
 
 std::string
 PyBool::py__str__()
 {
-    return value ? "True" : "False";
+    return value_ ? "True" : "False";
 }
 
 PyBool &
@@ -31,5 +31,5 @@ PyBool::get(bool value)
 bool
 PyBool::py__bool__()
 {
-    return value;
+    return value_;
 }

--- a/src/PyObj/PyFunc.cc
+++ b/src/PyObj/PyFunc.cc
@@ -3,20 +3,20 @@
 using namespace llvmPy;
 
 PyFunc::PyFunc(Frame *frame, void *label)
-: frame_(frame), label_(label)
+: _frame(frame), _label(label)
 {
 }
 
 Frame *
 PyFunc::getFrame() const
 {
-    return frame_;
+    return _frame;
 }
 
 void *
 PyFunc::getLabel() const
 {
-    return label_;
+    return _label;
 }
 
 std::string

--- a/src/PyObj/PyFunc.cc
+++ b/src/PyObj/PyFunc.cc
@@ -24,7 +24,7 @@ PyFunc::py__str__()
 {
     std::stringstream ss;
     ss << "<PyFunc ";
-    ss << std::hex << std::uppercase << (uint64_t) this;
+    ss << std::hex << std::uppercase << reinterpret_cast<uint64_t>(this);
     ss << ">";
     return ss.str();
 }

--- a/src/PyObj/PyInt.cc
+++ b/src/PyObj/PyInt.cc
@@ -3,20 +3,20 @@
 using namespace llvmPy;
 
 PyInt::PyInt(int64_t value)
-: value_(value)
+: _value(value)
 {
 }
 
 int64_t
 PyInt::getValue() const
 {
-    return value_;
+    return _value;
 }
 
 std::string
 PyInt::py__str__()
 {
-    return std::to_string(value_);
+    return std::to_string(_value);
 }
 
 PyObj *
@@ -96,11 +96,11 @@ PyInt::py__gt__(PyObj &rhs)
 bool
 PyInt::py__bool__()
 {
-    return value_ != 0;
+    return _value != 0;
 }
 
 int64_t
 PyInt::py__int__()
 {
-    return value_;
+    return _value;
 }

--- a/src/PyObj/PyInt.cc
+++ b/src/PyObj/PyInt.cc
@@ -3,20 +3,20 @@
 using namespace llvmPy;
 
 PyInt::PyInt(int64_t value)
-: value(value)
+: value_(value)
 {
 }
 
 int64_t
 PyInt::getValue() const
 {
-    return value;
+    return value_;
 }
 
 std::string
 PyInt::py__str__()
 {
-    return std::to_string(value);
+    return std::to_string(value_);
 }
 
 PyObj *
@@ -96,11 +96,11 @@ PyInt::py__gt__(PyObj &rhs)
 bool
 PyInt::py__bool__()
 {
-    return value != 0;
+    return value_ != 0;
 }
 
 int64_t
 PyInt::py__int__()
 {
-    return value;
+    return value_;
 }

--- a/src/PyObj/PyObj.cc
+++ b/src/PyObj/PyObj.cc
@@ -13,7 +13,7 @@ PyObj::py__str__()
 {
     std::stringstream ss;
     ss << "<PyObj 0x";
-    ss << std::hex << std::uppercase << (uint64_t) this;
+    ss << std::hex << std::uppercase << reinterpret_cast<uint64_t>(this);
     ss << ">";
     return ss.str();
 }

--- a/src/PyObj/PyObj.cc
+++ b/src/PyObj/PyObj.cc
@@ -6,6 +6,8 @@ using namespace llvmPy;
 
 PyObj::PyObj() = default;
 
+PyObj::~PyObj() = default;
+
 std::string
 PyObj::py__str__()
 {

--- a/src/PyObj/PyStr.cc
+++ b/src/PyObj/PyStr.cc
@@ -2,7 +2,7 @@
 using namespace llvmPy;
 
 PyStr::PyStr(std::unique_ptr<std::string const> value) noexcept
-: value_(std::move(value))
+: _value(std::move(value))
 {
 }
 
@@ -14,25 +14,25 @@ PyStr::PyStr(std::string const &value) noexcept
 std::string const &
 PyStr::getValue() const
 {
-    return *value_;
+    return *_value;
 }
 
 std::string
 PyStr::py__str__()
 {
-    return *value_;
+    return *_value;
 }
 
 bool
 PyStr::py__bool__()
 {
-    return !value_->empty();
+    return !_value->empty();
 }
 
 int64_t
 PyStr::py__len__()
 {
-    return static_cast<int64_t>(value_->size());
+    return static_cast<int64_t>(_value->size());
 }
 
 PyObj *

--- a/src/PyObj/PyStr.cc
+++ b/src/PyObj/PyStr.cc
@@ -2,7 +2,7 @@
 using namespace llvmPy;
 
 PyStr::PyStr(std::unique_ptr<std::string const> value) noexcept
-: value(std::move(value))
+: value_(std::move(value))
 {
 }
 
@@ -14,25 +14,25 @@ PyStr::PyStr(std::string const &value) noexcept
 std::string const &
 PyStr::getValue() const
 {
-    return *value;
+    return *value_;
 }
 
 std::string
 PyStr::py__str__()
 {
-    return *value;
+    return *value_;
 }
 
 bool
 PyStr::py__bool__()
 {
-    return !value->empty();
+    return !value_->empty();
 }
 
 int64_t
 PyStr::py__len__()
 {
-    return static_cast<int64_t>(value->size());
+    return static_cast<int64_t>(value_->size());
 }
 
 PyObj *

--- a/src/RT.cc
+++ b/src/RT.cc
@@ -8,7 +8,7 @@
 using namespace llvmPy;
 
 RT::RT(Compiler &compiler)
-: compiler(compiler)
+: _compiler(compiler)
 {
 }
 
@@ -16,6 +16,6 @@ void
 RT::import(RTModule &mod)
 {
     std::unique_ptr<llvm::Module> ptr(&mod.getModule());
-    compiler.addAndRunModule(std::move(ptr));
+    _compiler.addAndRunModule(std::move(ptr));
 }
 

--- a/src/RT.cc
+++ b/src/RT.cc
@@ -1,10 +1,15 @@
-#include <llvmPy/RT.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <llvm/IR/Module.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/Constants.h>
+#pragma GCC diagnostic pop
+
+#include <llvmPy/RT.h>
 #include <llvmPy/Instr.h>
 #include <llvmPy/Compiler.h>
-#include <llvm/IR/GlobalVariable.h>
 #include <string>
-#include <llvm/IR/Constants.h>
 using namespace llvmPy;
 
 RT::RT(Compiler &compiler)

--- a/src/RT/RTModule.cc
+++ b/src/RT/RTModule.cc
@@ -146,7 +146,7 @@ RTModule::llvmPy_PyInt(int64_t value) const
         return var;
     } else {
         auto *pyint = new PyInt(value);
-        auto *pyintAddr = types.getInt64(reinterpret_cast<uint64_t>(pyint));
+        auto *pyintAddr = types.getInt64(reinterpret_cast<int64_t>(pyint));
         auto *pyintPtr = llvm::ConstantExpr::getIntToPtr(pyintAddr, types.Ptr);
         return new llvm::GlobalVariable(
                 ir,
@@ -166,7 +166,7 @@ RTModule::llvmPy_PyStr(std::string const &value)
         return var->second;
     } else {
         auto *obj = new PyStr(value);
-        auto *addr = types.getInt64(reinterpret_cast<uint64_t>(obj));
+        auto *addr = types.getInt64(reinterpret_cast<int64_t>(obj));
         auto *ptr = llvm::ConstantExpr::getIntToPtr(addr, types.Ptr);
         auto *global = new llvm::GlobalVariable(
                 ir,

--- a/src/RT/RTModule.cc
+++ b/src/RT/RTModule.cc
@@ -1,11 +1,15 @@
-#include <llvmPy/RT.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/Module.h>
+#pragma GCC diagnostic pop
+
+#include <llvmPy/RT.h>
 #include <llvmPy/Instr.h>
 #include <llvmPy/Compiler.h>
-#include <llvm/IR/GlobalVariable.h>
 #include <string>
-#include <llvm/IR/Constants.h>
-
 using namespace llvmPy;
 
 RTModule::RTModule(

--- a/src/RT/RTModule.cc
+++ b/src/RT/RTModule.cc
@@ -16,106 +16,106 @@ RTModule::RTModule(
         std::string const &name,
         llvm::Module *module,
         Types const &types)
-        : ir(*module),
-          types(types),
-          scope(*this)
+        : _ir(*module),
+          _types(types),
+          _scope(*this)
 {
 }
 
 llvm::Value *
 RTModule::llvmPy_add() const
 {
-    return ir.getOrInsertFunction("llvmPy_add", types.llvmPy_add);
+    return _ir.getOrInsertFunction("llvmPy_add", _types.llvmPy_add);
 }
 
 llvm::Value *
 RTModule::llvmPy_sub() const
 {
-    return ir.getOrInsertFunction("llvmPy_sub", types.llvmPy_sub);
+    return _ir.getOrInsertFunction("llvmPy_sub", _types.llvmPy_sub);
 }
 
 llvm::Value *
 RTModule::llvmPy_mul() const
 {
-    return ir.getOrInsertFunction("llvmPy_mul", types.llvmPy_binop);
+    return _ir.getOrInsertFunction("llvmPy_mul", _types.llvmPy_binop);
 }
 
 llvm::Value *
 RTModule::llvmPy_int() const
 {
-    return ir.getOrInsertFunction("llvmPy_int", types.llvmPy_int);
+    return _ir.getOrInsertFunction("llvmPy_int", _types.llvmPy_int);
 }
 
 llvm::Value *
 RTModule::llvmPy_none() const
 {
-    return ir.getOrInsertFunction("llvmPy_none", types.llvmPy_none);
+    return _ir.getOrInsertFunction("llvmPy_none", _types.llvmPy_none);
 }
 
 llvm::Value *
 RTModule::llvmPy_func() const
 {
-    return ir.getOrInsertFunction("llvmPy_func", types.llvmPy_func);
+    return _ir.getOrInsertFunction("llvmPy_func", _types.llvmPy_func);
 }
 
 llvm::Value *
 RTModule::llvmPy_fchk() const
 {
-    return ir.getOrInsertFunction("llvmPy_fchk", types.llvmPy_fchk);
+    return _ir.getOrInsertFunction("llvmPy_fchk", _types.llvmPy_fchk);
 }
 
 llvm::Value *
 RTModule::llvmPy_print() const
 {
-    return ir.getOrInsertFunction("llvmPy_print", types.llvmPy_print);
+    return _ir.getOrInsertFunction("llvmPy_print", _types.llvmPy_print);
 }
 
 llvm::Value *
 RTModule::llvmPy_str() const
 {
-    return ir.getOrInsertFunction("llvmPy_str", types.llvmPy_str);
+    return _ir.getOrInsertFunction("llvmPy_str", _types.llvmPy_str);
 }
 
 llvm::Value *
 RTModule::llvmPy_bool() const
 {
-    return ir.getOrInsertFunction("llvmPy_bool", types.llvmPy_bool);
+    return _ir.getOrInsertFunction("llvmPy_bool", _types.llvmPy_bool);
 }
 
 llvm::Value *
 RTModule::llvmPy_lt() const
 {
-    return ir.getOrInsertFunction("llvmPy_lt", types.llvmPy_lt);
+    return _ir.getOrInsertFunction("llvmPy_lt", _types.llvmPy_lt);
 }
 
 llvm::Value *
 RTModule::llvmPy_le() const
 {
-    return ir.getOrInsertFunction("llvmPy_le", types.llvmPy_le);
+    return _ir.getOrInsertFunction("llvmPy_le", _types.llvmPy_le);
 }
 
 llvm::Value *
 RTModule::llvmPy_eq() const
 {
-    return ir.getOrInsertFunction("llvmPy_eq", types.llvmPy_eq);
+    return _ir.getOrInsertFunction("llvmPy_eq", _types.llvmPy_eq);
 }
 
 llvm::Value *
 RTModule::llvmPy_ne() const
 {
-    return ir.getOrInsertFunction("llvmPy_ne", types.llvmPy_ne);
+    return _ir.getOrInsertFunction("llvmPy_ne", _types.llvmPy_ne);
 }
 
 llvm::Value *
 RTModule::llvmPy_ge() const
 {
-    return ir.getOrInsertFunction("llvmPy_ge", types.llvmPy_ge);
+    return _ir.getOrInsertFunction("llvmPy_ge", _types.llvmPy_ge);
 }
 
 llvm::Value *
 RTModule::llvmPy_gt() const
 {
-    return ir.getOrInsertFunction("llvmPy_gt", types.llvmPy_gt);
+    return _ir.getOrInsertFunction("llvmPy_gt", _types.llvmPy_gt);
 }
 
 llvm::GlobalVariable *
@@ -142,15 +142,15 @@ RTModule::llvmPy_PyInt(int64_t value) const
     std::string sign = value < 0 ? "_" : "";
     std::string name = "PyInt." + sign + std::to_string(abs(value));
 
-    if (auto *var = ir.getGlobalVariable(name, true)) {
+    if (auto *var = _ir.getGlobalVariable(name, true)) {
         return var;
     } else {
         auto *pyint = new PyInt(value);
-        auto *pyintAddr = types.getInt64(reinterpret_cast<int64_t>(pyint));
-        auto *pyintPtr = llvm::ConstantExpr::getIntToPtr(pyintAddr, types.Ptr);
+        auto *pyintAddr = _types.getInt64(reinterpret_cast<int64_t>(pyint));
+        auto *pyintPtr = llvm::ConstantExpr::getIntToPtr(pyintAddr, _types.Ptr);
         return new llvm::GlobalVariable(
-                ir,
-                types.Ptr,
+                _ir,
+                _types.Ptr,
                 true,
                 llvm::GlobalVariable::LinkageTypes::PrivateLinkage,
                 pyintPtr,
@@ -166,11 +166,11 @@ RTModule::llvmPy_PyStr(std::string const &value)
         return var->second;
     } else {
         auto *obj = new PyStr(value);
-        auto *addr = types.getInt64(reinterpret_cast<int64_t>(obj));
-        auto *ptr = llvm::ConstantExpr::getIntToPtr(addr, types.Ptr);
+        auto *addr = _types.getInt64(reinterpret_cast<int64_t>(obj));
+        auto *ptr = llvm::ConstantExpr::getIntToPtr(addr, _types.Ptr);
         auto *global = new llvm::GlobalVariable(
-                ir,
-                types.Ptr,
+                _ir,
+                _types.Ptr,
                 true,
                 llvm::GlobalVariable::LinkageTypes::PrivateLinkage,
                 ptr,
@@ -183,24 +183,24 @@ RTModule::llvmPy_PyStr(std::string const &value)
 llvm::Value *
 RTModule::llvmPy_truthy() const
 {
-    return ir.getOrInsertFunction("llvmPy_truthy", types.llvmPy_truthy);
+    return _ir.getOrInsertFunction("llvmPy_truthy", _types.llvmPy_truthy);
 }
 
 llvm::Value *
 RTModule::llvmPy_len() const
 {
-    return ir.getOrInsertFunction("llvmPy_len", types.llvmPy_len);
+    return _ir.getOrInsertFunction("llvmPy_len", _types.llvmPy_len);
 }
 
 llvm::GlobalVariable *
 RTModule::getOrCreateGlobalExtern(std::string const &name) const
 {
-    if (auto *var = ir.getGlobalVariable(name)) {
+    if (auto *var = _ir.getGlobalVariable(name)) {
         return var;
     } else {
         return new llvm::GlobalVariable(
-                ir,
-                types.PyObj,
+                _ir,
+                _types.PyObj,
                 true,
                 llvm::GlobalVariable::LinkageTypes::ExternalLinkage,
                 nullptr,

--- a/src/RT/RTScope.cc
+++ b/src/RT/RTScope.cc
@@ -4,7 +4,7 @@ using namespace llvmPy;
 
 RTScope::RTScope(RTScope &parent)
 : Scope(parent),
-  module(parent.getModule()),
+  module_(parent.getModule()),
   innerFramePtrPtr(nullptr),
   innerFrameType(nullptr),
   outerFrameType(nullptr),
@@ -15,7 +15,7 @@ RTScope::RTScope(RTScope &parent)
 
 RTScope::RTScope(RTModule &module)
 : Scope(),
-  module(module),
+  module_(module),
   innerFramePtrPtr(nullptr),
   innerFrameType(nullptr),
   outerFrameType(nullptr),
@@ -33,7 +33,7 @@ RTScope::createDerived()
 RTModule &
 RTScope::getModule() const
 {
-    return module;
+    return module_;
 }
 
 llvm::Value *

--- a/src/RT/RTScope.cc
+++ b/src/RT/RTScope.cc
@@ -4,23 +4,23 @@ using namespace llvmPy;
 
 RTScope::RTScope(RTScope &parent)
 : Scope(parent),
-  module_(parent.getModule()),
-  innerFramePtrPtr(nullptr),
-  innerFrameType(nullptr),
-  outerFrameType(nullptr),
-  condStmtCount(0),
-  whileStmtCount(0)
+  _module(parent.getModule()),
+  _innerFramePtrPtr(nullptr),
+  _innerFrameType(nullptr),
+  _outerFrameType(nullptr),
+  _condStmtCount(0),
+  _whileStmtCount(0)
 {
 }
 
 RTScope::RTScope(RTModule &module)
 : Scope(),
-  module_(module),
-  innerFramePtrPtr(nullptr),
-  innerFrameType(nullptr),
-  outerFrameType(nullptr),
-  condStmtCount(0),
-  whileStmtCount(0)
+  _module(module),
+  _innerFramePtrPtr(nullptr),
+  _innerFrameType(nullptr),
+  _outerFrameType(nullptr),
+  _condStmtCount(0),
+  _whileStmtCount(0)
 {
 }
 
@@ -33,60 +33,60 @@ RTScope::createDerived()
 RTModule &
 RTScope::getModule() const
 {
-    return module_;
+    return _module;
 }
 
 llvm::Value *
 RTScope::getInnerFramePtrPtr() const
 {
-    return innerFramePtrPtr;
+    return _innerFramePtrPtr;
 }
 
 llvm::StructType *
 RTScope::getInnerFrameType() const
 {
-    assert(innerFrameType);
-    return innerFrameType;
+    assert(_innerFrameType);
+    return _innerFrameType;
 }
 
 void
 RTScope::setInnerFrameType(llvm::StructType *st)
 {
-    innerFrameType = st;
+    _innerFrameType = st;
 }
 
 llvm::StructType *
 RTScope::getOuterFrameType() const
 {
-    assert(outerFrameType);
-    return outerFrameType;
+    assert(_outerFrameType);
+    return _outerFrameType;
 }
 
 void
 RTScope::setOuterFrameType(llvm::StructType *st)
 {
-    outerFrameType = st;
+    _outerFrameType = st;
 }
 
 void
 RTScope::setInnerFramePtrPtr(llvm::Value *ptr)
 {
-    innerFramePtrPtr = ptr;
+    _innerFramePtrPtr = ptr;
 }
 
 bool
 RTScope::hasSlot(std::string const &name) const
 {
-    return slots.count(name) > 0;
+    return _slots.count(name) > 0;
 }
 
 void
 RTScope::declareSlot(std::string const &name)
 {
     if (!hasSlot(name)) {
-        slots[name] = {
+        _slots[name] = {
                 .value = nullptr,
-                .frameIndex = slots.size()
+                .frameIndex = _slots.size()
         };
     }
 }
@@ -95,49 +95,49 @@ llvm::Value *
 RTScope::getSlotValue(std::string const &name) const
 {
     assert(hasSlot(name));
-    return slots.at(name).value;
+    return _slots.at(name).value;
 }
 
 void
 RTScope::setSlotValue(std::string const &name, llvm::Value *value)
 {
     assert(hasSlot(name));
-    slots.at(name).value = value;
+    _slots.at(name).value = value;
 }
 
 size_t
 RTScope::getSlotIndex(std::string const &name) const
 {
     assert(hasSlot(name));
-    return slots.at(name).frameIndex;
+    return _slots.at(name).frameIndex;
 }
 
 size_t
 RTScope::getSlotCount() const
 {
-    return slots.size();
+    return _slots.size();
 }
 
 llvm::Value *
 RTScope::getInnerFramePtr() const
 {
-    return innerFramePtr;
+    return _innerFramePtr;
 }
 
 void
 RTScope::setInnerFramePtr(llvm::Value *ptr)
 {
-    innerFramePtr = ptr;
+    _innerFramePtr = ptr;
 }
 
 size_t
 RTScope::getNextCondStmtIndex()
 {
-    return condStmtCount++;
+    return _condStmtCount++;
 }
 
 size_t
 RTScope::getNextWhileStmtIndex()
 {
-    return whileStmtCount++;
+    return _whileStmtCount++;
 }

--- a/src/RT/Scope.cc
+++ b/src/RT/Scope.cc
@@ -3,12 +3,12 @@
 using namespace llvmPy;
 
 Scope::Scope()
-: parent(nullptr)
+: parent_(nullptr)
 {
 }
 
 Scope::Scope(Scope &parent)
-: parent(&parent)
+: parent_(&parent)
 {
 }
 
@@ -17,12 +17,12 @@ Scope::~Scope() = default;
 bool
 Scope::hasParent() const
 {
-    return parent != nullptr;
+    return parent_ != nullptr;
 }
 
 Scope &
 Scope::getParent() const
 {
     assert(hasParent());
-    return *parent;
+    return *parent_;
 }

--- a/src/RT/Scope.cc
+++ b/src/RT/Scope.cc
@@ -3,12 +3,12 @@
 using namespace llvmPy;
 
 Scope::Scope()
-: parent_(nullptr)
+: _parent(nullptr)
 {
 }
 
 Scope::Scope(Scope &parent)
-: parent_(&parent)
+: _parent(&parent)
 {
 }
 
@@ -17,12 +17,12 @@ Scope::~Scope() = default;
 bool
 Scope::hasParent() const
 {
-    return parent_ != nullptr;
+    return _parent != nullptr;
 }
 
 Scope &
 Scope::getParent() const
 {
     assert(hasParent());
-    return *parent_;
+    return *_parent;
 }

--- a/src/Support/Typed.cc
+++ b/src/Support/Typed.cc
@@ -1,0 +1,4 @@
+#include <llvmPy/Typed.h>
+using namespace llvmPy;
+
+Typed::~Typed() = default;

--- a/src/Token.cc
+++ b/src/Token.cc
@@ -4,40 +4,40 @@ using namespace llvmPy;
 using namespace std;
 
 Token::Token(TokenType type)
-: type(type), str(nullptr), depth(0)
+: _type(type), _str(nullptr), _depth(0)
 {
 
 }
 
 Token::Token(TokenType type, std::unique_ptr<std::string> str)
-: type(type), str(std::move(str)), depth(0)
+: _type(type), _str(std::move(str)), _depth(0)
 {
 
 }
 
 Token::Token(TokenType type, size_t depth)
-: type(type), str(nullptr), depth(depth)
+: _type(type), _str(nullptr), _depth(depth)
 {
 }
 
 TokenType
 Token::getTokenType() const
 {
-    return type;
+    return _type;
 }
 
 std::string const &
 Token::getString() const
 {
-    assert(str);
-    return *str;
+    assert(_str);
+    return *_str;
 }
 
 size_t
 Token::getDepth() const
 {
     assert(getTokenType() == tok_indent);
-    return depth;
+    return _depth;
 }
 
 std::ostream &

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,24 +13,24 @@ using std::cout;
 using std::endl;
 using std::string;
 
-cl::opt<string> Cmd(
+static cl::opt<string> Cmd(
         "c",
         cl::desc("Program passed as string."),
         cl::value_desc("cmd"));
 
-cl::opt<bool> IsIR(
+static cl::opt<bool> IsIR(
         "ir",
         cl::desc("Print resulting LLVM IR and exit."));
 
-cl::opt<bool> IsParser(
+static cl::opt<bool> IsParser(
         "parser",
         cl::desc("Print resulting parser tree and exit."));
 
-cl::opt<bool> IsLexer(
+static cl::opt<bool> IsLexer(
         "lexer",
         cl::desc("Print tokens output by the lexer and exit."));
 
-cl::opt<string> Filename(
+static cl::opt<string> Filename(
         cl::Positional,
         cl::desc("file"));
 

--- a/test/Builtins/bool/builtin_bool.cc
+++ b/test/Builtins/bool/builtin_bool.cc
@@ -1,7 +1,7 @@
 #include <llvmPy/Instr.h>
 #include <llvmPy/PyObj/PyObj.h>
-#include <catch2/catch.hpp>
-#include <fakeit.hpp>
+#include <catch2.h>
+#include <fakeit.h>
 using namespace llvmPy;
 using namespace fakeit;
 

--- a/test/Builtins/func/instr_func.cc
+++ b/test/Builtins/func/instr_func.cc
@@ -15,8 +15,10 @@ allocFrame(size_t slotCount) {
 
 TEST_CASE("instr: llvmPy_func()", "[instr][func]") {
     SECTION("it stores the frame and function pointers") {
+        Mock<Scope> parentScope;
         Mock<Scope> scope;
         When(Method(scope, hasParent)).AlwaysReturn(false);
+        When(Method(scope, getParent)).AlwaysReturn(parentScope.get());
 
         Frame frame;
         frame.self = reinterpret_cast<Frame *>(123);

--- a/test/Builtins/func/instr_func.cc
+++ b/test/Builtins/func/instr_func.cc
@@ -1,7 +1,7 @@
 #include <llvmPy/Instr.h>
 #include <llvmPy/RT/Scope.h>
-#include <catch2/catch.hpp>
-#include <fakeit.hpp>
+#include <catch2.h>
+#include <fakeit.h>
 using namespace llvmPy;
 using namespace fakeit;
 
@@ -14,13 +14,10 @@ allocFrame(size_t slotCount) {
 }
 
 TEST_CASE("instr: llvmPy_func()", "[instr][func]") {
-    Mock<Scope> parentScope;
-    Mock<Scope> scope;
-
-    When(Method(scope, hasParent)).AlwaysReturn(true);
-    When(Method(scope, getParent)).AlwaysReturn(parentScope.get());
-
     SECTION("it stores the frame and function pointers") {
+        Mock<Scope> scope;
+        When(Method(scope, hasParent)).AlwaysReturn(false);
+
         Frame frame;
         frame.self = reinterpret_cast<Frame *>(123);
         frame.setIsPointingToHeap();
@@ -33,7 +30,6 @@ TEST_CASE("instr: llvmPy_func()", "[instr][func]") {
         PyFunc *pyfunc = llvmPy_func(&frame, label);
         Verify(Method(scope, getParent)).Once();
         VerifyNoOtherInvocations(scope);
-        VerifyNoOtherInvocations(parentScope);
         CHECK(pyfunc->getFrame() == reinterpret_cast<Frame *>(123));
         CHECK(pyfunc->getLabel() == label);
     }
@@ -52,11 +48,15 @@ TEST_CASE("instr: llvmPy_func()", "[instr][func]") {
         PyInt i1(1), i2(2), i3(3), i4(4);
 
         SECTION("it should return null and do nothing if the frame is null") {
+            Mock<Scope> scope;
+            When(Method(scope, hasParent)).AlwaysReturn(false);
             auto *actual = moveFrameToHeap(nullptr, scope.get());
             CHECK(actual == nullptr);
         }
 
         SECTION("it should return the same frame if it's already relocated") {
+            Mock<Scope> scope;
+            When(Method(scope, hasParent)).AlwaysReturn(false);
             Frame frame;
             frame.self = reinterpret_cast<Frame *>(123);
             frame.setIsPointingToHeap();

--- a/test/Builtins/str/builtin_str.cc
+++ b/test/Builtins/str/builtin_str.cc
@@ -1,7 +1,7 @@
 #include <llvmPy/Instr.h>
 #include <llvmPy/PyObj/PyObj.h>
-#include <catch2/catch.hpp>
-#include <fakeit.hpp>
+#include <catch2.h>
+#include <fakeit.h>
 using namespace llvmPy;
 using namespace fakeit;
 

--- a/test/Builtins/truthy/instr_truthy.cc
+++ b/test/Builtins/truthy/instr_truthy.cc
@@ -1,7 +1,7 @@
 #include <llvmPy/Instr.h>
 #include <llvmPy/PyObj/PyObj.h>
-#include <catch2/catch.hpp>
-#include <fakeit.hpp>
+#include <catch2.h>
+#include <fakeit.h>
 using namespace llvmPy;
 using namespace fakeit;
 

--- a/test/Types/PyStr/type_PyStr.cc
+++ b/test/Types/PyStr/type_PyStr.cc
@@ -1,7 +1,7 @@
 #include <llvmPy/Instr.h>
 #include <llvmPy/PyObj/PyObj.h>
-#include <catch2/catch.hpp>
-#include <fakeit.hpp>
+#include <catch2.h>
+#include <fakeit.h>
 using namespace llvmPy;
 using namespace fakeit;
 

--- a/test/include/catch2.h
+++ b/test/include/catch2.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <catch2/catch.hpp>
+#pragma GCC diagnostic pop

--- a/test/include/fakeit.h
+++ b/test/include/fakeit.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weverything"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <fakeit.hpp>
+#pragma GCC diagnostic pop


### PR DESCRIPTION
- Enables `-Weverything -pedantic` (with some warnings explicitly disabled).
- The flags are disabled around LLVM header imports in a manner specific to GCC and Clang.
- In response to shadowing warnings, permeates the convention of prefix underscore for private variables. The rationale (compared to the suffix underscore) is that it's less likely to lead to false completions with IDE auto-completion.