### PR TITLE
Caller-loaded call frames

### DIFF
--- a/include/llvmPy/PyObj/PyStr.h
+++ b/include/llvmPy/PyObj/PyStr.h
@@ -31,9 +31,9 @@ public:
 
     PyObj *py__getattr__(std::string const &name) override;
 
-    static PyObj *py_upper(PyStr **self);
+    static PyObj *py_upper(PyStr &self);
 
-    static PyObj *py_capitalize(PyStr **self);
+    static PyObj *py_capitalize(PyStr &self);
 
 private:
     std::unique_ptr<std::string const> _value;

--- a/src/Instr.cc
+++ b/src/Instr.cc
@@ -88,7 +88,7 @@ llvm::FunctionType *
 Types::getOpaqueFunc(size_t N) const
 {
     std::vector<llvm::Type *> argTypes;
-    argTypes.push_back(FramePtrPtr);
+    argTypes.push_back(FramePtr);
 
     for (size_t i = 0; i < N; ++i) {
         argTypes.push_back(Ptr);
@@ -104,7 +104,7 @@ Types::getFunc(
         size_t N) const
 {
     std::vector<llvm::Type *> argTypes;
-    argTypes.push_back(getPtr(getPtr(outer)));
+    argTypes.push_back(getPtr(outer));
 
     for (size_t i = 0; i < N; ++i) {
         argTypes.push_back(Ptr);

--- a/src/PyObj/PyStr.cc
+++ b/src/PyObj/PyStr.cc
@@ -98,15 +98,13 @@ PyStr::py__getattr__(std::string const &name)
 }
 
 PyObj *
-PyStr::py_upper(PyStr **self)
+PyStr::py_upper(PyStr &self)
 {
-    PyStr &str = **self;
-
-    if (str.getValue().empty()) {
-        return &str;
+    if (self.getValue().empty()) {
+        return &self;
     }
 
-    auto s = std::make_unique<std::string>(str.getValue());
+    auto s = std::make_unique<std::string>(self.getValue());
     std::transform(
             s->begin(),
             s->end(),
@@ -116,15 +114,13 @@ PyStr::py_upper(PyStr **self)
 }
 
 PyObj *
-PyStr::py_capitalize(PyStr **self)
+PyStr::py_capitalize(PyStr &self)
 {
-    PyStr &str = **self;
-
-    if (str.getValue().empty()) {
-        return &str;
+    if (self.getValue().empty()) {
+        return &self;
     }
 
-    auto s = std::make_unique<std::string>(str.getValue());
+    auto s = std::make_unique<std::string>(self.getValue());
     std::transform(
             s->begin(),
             s->end(),

--- a/test/Internals/Frames/empty-module.py
+++ b/test/Internals/Frames/empty-module.py
@@ -4,12 +4,11 @@
 # IR-DAG: %Frame = type opaque
 # IR-DAG: %Frame.__body__ = type <{ %Frame.__body__*, %Frame*, [0 x %PyObj*] }>
 
-# IR-LABEL: define %PyObj* @__body__(%Frame** %outerptr) prefix i64 {{[0-9]+}} {
+# IR-LABEL: define %PyObj* @__body__(%Frame* %outer) prefix i64 {{[0-9]+}} {
 #  IR-NEXT:     %frame = alloca %Frame.__body__
 #  IR-NEXT:     %1 = getelementptr %Frame.__body__, %Frame.__body__* %frame, i64 0, i32 0
 #  IR-NEXT:     %2 = getelementptr %Frame.__body__, %Frame.__body__* %frame, i64 0, i32 1
 #  IR-NEXT:     store %Frame.__body__* %frame, %Frame.__body__** %1
-#  IR-NEXT:     %outer = load %Frame*, %Frame** %outerptr
 #  IR-NEXT:     store %Frame* %outer, %Frame** %2
 #  IR-NEXT:     %callframe = alloca %Frame*
 #  IR-NEXT:     ret %PyObj* @llvmPy_None

--- a/test/Internals/Frames/module-functions.py
+++ b/test/Internals/Frames/module-functions.py
@@ -10,19 +10,19 @@
 # IR-LABEL: define %PyObj* @__body__
 # IR: alloca %Frame.__body__
 
-# IR-LABEL: define %PyObj* @first(%Frame.__body__** %outerptr)
+# IR-LABEL: define %PyObj* @first(%Frame.__body__* %outer)
 # IR: alloca %Frame.first
 def first():
     return 1 + 2
 
 
-# IR-LABEL: define %PyObj* @second(%Frame.__body__** %outerptr, %PyObj* %arg.x)
+# IR-LABEL: define %PyObj* @second(%Frame.__body__* %outer, %PyObj* %arg.x)
 # IR: alloca %Frame.second
 def second(x):
     return 2 * x
 
 
-# IR-LABEL: define %PyObj* @third(%Frame.__body__** %outerptr, %PyObj* %arg.x)
+# IR-LABEL: define %PyObj* @third(%Frame.__body__* %outer, %PyObj* %arg.x)
 # IR: alloca %Frame.third
 def third(x):
     def fourth(y):
@@ -30,5 +30,5 @@ def third(x):
     return fourth
 
 
-# IR-LABEL: define %PyObj* @fourth(%Frame.third** %outerptr, %PyObj* %arg.y)
+# IR-LABEL: define %PyObj* @fourth(%Frame.third* %outer, %PyObj* %arg.y)
 # IR: alloca %Frame.fourth

--- a/test/Syntax/Expressions/call/call0.py
+++ b/test/Syntax/Expressions/call/call0.py
@@ -10,7 +10,8 @@ f = None
 f()
 # IR: [[fPtr1:%[^ ]+]] = load %PyObj*, %PyObj** %var.f1
 # IR-NEXT: [[fLabel:%[^ ]+]] = call i8* @llvmPy_fchk(%Frame** %callframe, %PyObj* [[fPtr1]], i64 0)
-# IR-NEXT: [[fFunc:%[^ ]+]] = bitcast i8* [[fLabel]] to %PyObj* (%Frame**)*
-# IR-NEXT: [[fRV:%[^ ]+]] = call %PyObj* [[fFunc]](%Frame** %callframe)
+# IR-NEXT: [[callframe:%[^ ]+]] = load %Frame*, %Frame** %callframe
+# IR-NEXT: [[fFunc:%[^ ]+]] = bitcast i8* [[fLabel]] to %PyObj* (%Frame*)*
+# IR-NEXT: [[fRV:%[^ ]+]] = call %PyObj* [[fFunc]](%Frame* [[callframe]])
 
-# CHECK-DAG: declare i8* @llvmPy_fchk(%FrameN**, %PyObj*, i64)
+# IR-DAG: declare i8* @llvmPy_fchk(%Frame**, %PyObj*, i64)

--- a/test/Syntax/Expressions/call/call1.py
+++ b/test/Syntax/Expressions/call/call1.py
@@ -9,7 +9,8 @@ f = None
 f(1)
 # IR: [[fPtr1:%[^ ]+]] = load %PyObj*, %PyObj** %var.f1
 # IR: [[fLabel:%[^ ]+]] = call i8* @llvmPy_fchk(%Frame** %callframe, %PyObj* [[fPtr1]], i64 1)
-# IR-NEXT: [[fFunc:%[^ ]+]] = bitcast i8* [[fLabel]] to %PyObj* (%Frame**, %PyObj*)*
-# IR-NEXT: [[fRV:%[^ ]+]] = call %PyObj* [[fFunc]](%Frame** %callframe, %PyObj* %PyInt.1)
+# IR-NEXT: [[callframe:%[^ ]+]] = load %Frame*, %Frame** %callframe
+# IR-NEXT: [[fFunc:%[^ ]+]] = bitcast i8* [[fLabel]] to %PyObj* (%Frame*, %PyObj*)*
+# IR-NEXT: [[fRV:%[^ ]+]] = call %PyObj* [[fFunc]](%Frame* [[callframe]], %PyObj* %PyInt.1)
 
 # IR-DAG: declare i8* @llvmPy_fchk(%Frame**, %PyObj*, i64)

--- a/test/Syntax/Expressions/getattr/getattr-call.py
+++ b/test/Syntax/Expressions/getattr/getattr-call.py
@@ -13,12 +13,12 @@ print("test".upper().capitalize())
 # IR: [[str:%[^ ]+]] = load %PyObj*, %PyObj** @PyStr.0
 # IR: [[upper:%[^ ]+]] = call %PyObj* @llvmPy_getattr(%PyObj* [[str]], %PyObj* %PyStr.1)
 # IR: [[upperFunc_:%[^ ]+]] = call i8* @llvmPy_fchk(%Frame** %callframe, %PyObj* [[upper]], i64 0)
-# IR: [[upperFunc:%[^ ]+]] = bitcast i8* [[upperFunc_]] to %PyObj* (%Frame**)*
-# IR: [[upperVal:%[^ ]+]] = call %PyObj* [[upperFunc]](%Frame** %callframe)
+# IR: [[upperFunc:%[^ ]+]] = bitcast i8* [[upperFunc_]] to %PyObj* (%Frame*)*
+# IR: [[upperVal:%[^ ]+]] = call %PyObj* [[upperFunc]](%Frame* {{%[^ ]+}})
 # IR: [[capitalize:%[^ ]+]] = call %PyObj* @llvmPy_getattr(%PyObj* [[upperVal]], %PyObj* %PyStr.2)
 # IR: [[capitalizeFunc_:%[^ ]+]] = call i8* @llvmPy_fchk(%Frame** %callframe, %PyObj* [[capitalize]], i64 0)
-# IR: [[capitalizeFunc:%[^ ]+]] = bitcast i8* [[capitalizeFunc_]] to %PyObj* (%Frame**)*
-# IR: [[capitalizeVal:%[^ ]+]] = call %PyObj* [[capitalizeFunc]](%Frame** %callframe)
+# IR: [[capitalizeFunc:%[^ ]+]] = bitcast i8* [[capitalizeFunc_]] to %PyObj* (%Frame*)*
+# IR: [[capitalizeVal:%[^ ]+]] = call %PyObj* [[capitalizeFunc]](%Frame* {{%[^ ]+}})
 # IR: @llvmPy_print(%PyObj* [[capitalizeVal]])
 
 # OUTPUT: Test

--- a/test/Types/PyStr/type_PyStr.cc
+++ b/test/Types/PyStr/type_PyStr.cc
@@ -6,7 +6,7 @@ using namespace llvmPy;
 using namespace fakeit;
 
 static void
-checkMethodPtr(PyStr &s, std::string name, PyObj*(*method)(PyStr **))
+checkMethodPtr(PyStr &s, std::string name, PyObj*(*method)(PyStr &))
 {
     PyFunc &f = s.py__getattr__(name)->as<PyFunc>();
 
@@ -79,19 +79,17 @@ TEST_CASE("type: PyStr", "[types][PyStr]") {
     }
 
     SECTION("py_upper(): convert string to uppercase") {
-        auto *s1p = &s1, *s7p = &s7;
-        auto *r1 = PyStr::py_upper(&s1p);
+        auto *r1 = PyStr::py_upper(s1);
         CHECK(r1->as<PyStr>().getValue() == "");
-        auto *r7 = PyStr::py_upper(&s7p);
+        auto *r7 = PyStr::py_upper(s7);
         CHECK(r7->as<PyStr>().getValue() == "TRUE");
 
     }
 
     SECTION("py_capitalize(): capitalize string") {
-        auto *s1p = &s1, *s3p = &s3;
-        auto *r1 = PyStr::py_capitalize(&s1p);
+        auto *r1 = PyStr::py_capitalize(s1);
         CHECK(r1->as<PyStr>().getValue() == "");
-        auto *r3 = PyStr::py_capitalize(&s3p);
+        auto *r3 = PyStr::py_capitalize(s3);
         CHECK(r3->as<PyStr>().getValue() == "Test");
     }
 }


### PR DESCRIPTION
- Replace the `%Frame**` argument to functions with `%Frame*`, hence forcing the caller to load the value first.
- This approach is likely to lead to some unnecessary loads (e.g. for library functions that ignore the value anyway, or user functions that don't care for the lexical scope), but makes the interfaces a bit neater. In the long term, with the help of some calling convention shenanigans the extra parameters could be returned by fchk in registers instead.